### PR TITLE
feat: Image Booru Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ihaapi-ts",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "A maybe-pretty-fast API endpoint mainly made for VTuber stuff.",
   "main": "src/main.ts",
   "scripts": {

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -91,6 +91,12 @@
         "Use the new Database schemas, this also introduce a much longer cursor"
     ],
     "2.5.0": [
-        "Codebase rework"
+        "Codebase rework",
+        "GraphQL subscription support, only for VTuber API now."
+    ],
+    "2.5.1": [
+        "ImageBooru Board support",
+        "Added Danbooru, Konachan, and Gelbooru Support for now.",
+        "More documentation of the GraphQL API, this time is for the API References"
     ]
 }

--- a/src/config.ts.example
+++ b/src/config.ts.example
@@ -1,3 +1,5 @@
+import { Nullable } from "./utils/swissknife";
+
 interface IAPIConfiguration {
     mongodb: {
         uri: string;
@@ -25,6 +27,20 @@ interface IAPIConfiguration {
         twitch: {
             client?: string | null;
             secret?: string | null;
+        };
+    };
+    imageboard: {
+        enabled: boolean;
+        danbooru: {
+            enable?: boolean;
+        };
+        konachan: {
+            enable?: boolean;
+        };
+        gelbooru: {
+            enable?: boolean;
+            user_id?: Nullable<string>;
+            api_key?: Nullable<string>;
         };
     };
     features: {
@@ -111,6 +127,29 @@ const CONFIGURATION: IAPIConfiguration = {
             client: null,
             secret: null,
         }
+    },
+    /**
+     * Image Booru API Helper
+     * -----------------------------
+     *
+     * `enabled` key are global, if set to enable it will default everything to the one that being set.
+     * It can be overriden by setting it per "Boord".
+     *
+     * Gelbooru: You can use your own User ID and API Key to bypass some restrictions (default to `null`)
+     */
+    imageboard: {
+        enabled: true,
+        danbooru: {
+            enable: true,
+        },
+        konachan: {
+            enable: true,
+        },
+        gelbooru: {
+            enable: true,
+            user_id: null,
+            api_key: null,
+        },
     },
     /**
      * This is extra feature that the API can have

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -3,7 +3,7 @@ import { ApolloServer } from "apollo-server-express";
 import { ApolloServerPluginInlineTraceDisabled } from "apollo-server-core";
 
 import { CustomRedisCache } from "./caches/redis";
-import { nHGQLSchemas, SauceAPIGQL, v2Definitions, VTAPIv2 } from "./schemas";
+import { ImageBooruSchemas, nHGQLSchemas, SauceAPIGQL, v2Definitions, VTAPIv2 } from "./schemas";
 import { v2Resolvers } from "./resolvers";
 import { SubscriptionResolver, v2SubscriptionSchemas } from "./subscription";
 import { IQDBAPI, SauceNAOAPI } from "./datasources";
@@ -24,7 +24,7 @@ const cacheServers = new CustomRedisCache({
     password: is_none(REDIS_PASSWORD) ? undefined : REDIS_PASSWORD,
 });
 
-let typeDefs = [VTAPIv2, SauceAPIGQL, nHGQLSchemas, v2Definitions];
+let typeDefs = [VTAPIv2, SauceAPIGQL, nHGQLSchemas, ImageBooruSchemas, v2Definitions];
 const v2ResolversFinal = v2Resolvers;
 if (!is_none(process.env.REPLICA_SET) && process.env.REPLICA_SET.length > 0) {
     logger.info("Enabling replica subscription (schemas)...");

--- a/src/graphql/resolvers/imagebooru.ts
+++ b/src/graphql/resolvers/imagebooru.ts
@@ -7,7 +7,7 @@ import { GraphQLJSON } from "graphql-type-json";
 import { BoardEngine, ImageBoardParams, ImageBoardResult, ImageBoardResults } from "../schemas";
 import { CustomRedisCache } from "../caches/redis";
 
-import { DanbooruBoard, GelbooruBoard, KonachanBoard } from "../../utils/imagebooru";
+import { DanbooruBoard, E621Board, GelbooruBoard, KonachanBoard } from "../../utils/imagebooru";
 import { ImageBoardResultsBase } from "../../utils/imagebooru/base";
 import { logger as TopLogger } from "../../utils/logger";
 import _ from "lodash";
@@ -21,9 +21,16 @@ interface ImageBoardContext {
 
 const ImageBoardMapping = {
     danbooru: new DanbooruBoard(),
-    safebooru: new DanbooruBoard(true),
     konachan: new KonachanBoard(),
     gelbooru: new GelbooruBoard(),
+    e621: new E621Board(),
+};
+
+const ImageBoardMappingSafe = {
+    danbooru: new DanbooruBoard(true),
+    konachan: new KonachanBoard(true),
+    gelbooru: new GelbooruBoard(true),
+    e621: new E621Board(true),
 };
 
 export const ImageBooruGQLResolver: IResolvers<any, ImageBoardContext> = {
@@ -37,8 +44,9 @@ export const ImageBooruGQLResolver: IResolvers<any, ImageBoardContext> = {
                 Object.keys(ImageBoardMapping).includes(engine.toLowerCase())
             );
             selectedEngine = selectedEngine.map((e) => e.toLowerCase() as BoardEngine);
+            const usingMappings = args.safeVersion ? ImageBoardMappingSafe : ImageBoardMapping;
             const requesterTasks = selectedEngine.map((engine) =>
-                ImageBoardMapping[engine]
+                usingMappings[engine]
                     .search(args.tags, args.page)
                     // @ts-ignore
                     .then((res: ImageBoardResultsBase<ImageBoardResult>) => {
@@ -70,8 +78,9 @@ export const ImageBooruGQLResolver: IResolvers<any, ImageBoardContext> = {
                 Object.keys(ImageBoardMapping).includes(engine.toLowerCase())
             );
             selectedEngine = selectedEngine.map((e) => e.toLowerCase() as BoardEngine);
+            const usingMappings = args.safeVersion ? ImageBoardMappingSafe : ImageBoardMapping;
             const requesterTasks = selectedEngine.map((engine) =>
-                ImageBoardMapping[engine]
+                usingMappings[engine]
                     .random(args.tags, args.page)
                     // @ts-ignore
                     .then((res: ImageBoardResultsBase<ImageBoardResult>) => {

--- a/src/graphql/resolvers/imagebooru.ts
+++ b/src/graphql/resolvers/imagebooru.ts
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import "apollo-cache-control";
+import express from "express";
+import { IResolvers } from "apollo-server-express";
+import { GraphQLJSON } from "graphql-type-json";
+
+import { BoardEngine, ImageBoardParams, ImageBoardResult, ImageBoardResults } from "../schemas";
+import { CustomRedisCache } from "../caches/redis";
+
+import { DanbooruBoard, GelbooruBoard, KonachanBoard } from "../../utils/imagebooru";
+import { ImageBoardResultsBase } from "../../utils/imagebooru/base";
+import { logger as TopLogger } from "../../utils/logger";
+import _ from "lodash";
+
+const MainLogger = TopLogger.child({ cls: "ImageBooruGQL" });
+interface ImageBoardContext {
+    req: express.Request;
+    res: express.Response;
+    cacheServers: CustomRedisCache;
+}
+
+const ImageBoardMapping = {
+    danbooru: new DanbooruBoard(),
+    safebooru: new DanbooruBoard(true),
+    konachan: new KonachanBoard(),
+    gelbooru: new GelbooruBoard(),
+};
+
+export const ImageBooruGQLResolver: IResolvers<any, ImageBoardContext> = {
+    JSON: GraphQLJSON,
+    Query: {
+        search: async (_s, args: ImageBoardParams, ctx, _i): Promise<ImageBoardResults> => {
+            const logger = MainLogger.child({ fn: "search" });
+            let selectedEngine = args.engine;
+            // Filter engine to make sure it will be not undefined
+            selectedEngine = selectedEngine.filter((engine) =>
+                Object.keys(ImageBoardMapping).includes(engine.toLowerCase())
+            );
+            selectedEngine = selectedEngine.map((e) => e.toLowerCase() as BoardEngine);
+            const requesterTasks = selectedEngine.map((engine) =>
+                ImageBoardMapping[engine]
+                    .search(args.tags, args.page)
+                    // @ts-ignore
+                    .then((res: ImageBoardResultsBase<ImageBoardResult>) => {
+                        const remappedData = res.results.map((r) => {
+                            r["engine"] = engine;
+                            return r;
+                        });
+                        return remappedData;
+                    })
+                    .catch((err: Error) => {
+                        logger.error(
+                            `An error occured when fetching from engine ${engine}, ${err.toString()}`
+                        );
+                        return [];
+                    })
+            );
+            let executedData = await Promise.all(requesterTasks);
+            executedData = _.flattenDeep(executedData);
+            return {
+                results: executedData,
+                total: executedData.length,
+            };
+        },
+        random: async (_s, args: ImageBoardParams, ctx, _i): Promise<ImageBoardResults> => {
+            const logger = MainLogger.child({ fn: "random" });
+            let selectedEngine = args.engine;
+            // Filter engine to make sure it will be not undefined
+            selectedEngine = selectedEngine.filter((engine) =>
+                Object.keys(ImageBoardMapping).includes(engine.toLowerCase())
+            );
+            selectedEngine = selectedEngine.map((e) => e.toLowerCase() as BoardEngine);
+            const requesterTasks = selectedEngine.map((engine) =>
+                ImageBoardMapping[engine]
+                    .random(args.tags, args.page)
+                    // @ts-ignore
+                    .then((res: ImageBoardResultsBase<ImageBoardResult>) => {
+                        const remappedData = res.results.map((r) => {
+                            r["engine"] = engine;
+                            return r;
+                        });
+                        return remappedData;
+                    })
+                    .catch((err: Error) => {
+                        logger.error(
+                            `An error occured when fetching from engine ${engine}, ${err.toString()}`
+                        );
+                        return [];
+                    })
+            );
+            let executedData = await Promise.all(requesterTasks);
+            executedData = _.flattenDeep(executedData);
+            return {
+                results: executedData,
+                total: executedData.length,
+            };
+        },
+    },
+};

--- a/src/graphql/resolvers/index.ts
+++ b/src/graphql/resolvers/index.ts
@@ -4,6 +4,7 @@ import { IResolvers } from "apollo-server-express";
 import { SauceGQLResoler } from "./saucefinder";
 import { VTAPIv2Resolvers } from "./vtapi";
 import { nhGQLResolvers } from "./nh";
+import { ImageBooruGQLResolver } from "./imagebooru";
 
 export * from "./vtapi";
 export * from "./nh";
@@ -14,10 +15,12 @@ const multiResolvers: IResolvers = {
         vtuber: () => ({}),
         sauce: () => ({}),
         nhentai: () => ({}),
+        imagebooru: () => ({}),
     },
     VTuberQuery: VTAPIv2Resolvers["Query"],
     SauceQuery: SauceGQLResoler["Query"],
     nHentaiQuery: nhGQLResolvers["Query"],
+    ImageBoardQuery: ImageBooruGQLResolver["Query"],
 };
 
 const vtresolver = _.omit(VTAPIv2Resolvers, ["Query"]);

--- a/src/graphql/schemas/imagebooru.ts
+++ b/src/graphql/schemas/imagebooru.ts
@@ -8,6 +8,8 @@ export const ImageBooruSchemas = gql`
     enum BoardEngine {
         "danbooru.donmai.us"
         danbooru
+        "danbooru.donmai.us with rating:safe"
+        safebooru
     }
 
     type ImageInfo {
@@ -55,7 +57,7 @@ export const ImageBooruSchemas = gql`
     }
 `;
 
-export type BoardEngine = "danbooru";
+export type BoardEngine = "danbooru" | "safebooru";
 
 export interface ImageInfo {
     w?: Nullable<number>;

--- a/src/graphql/schemas/imagebooru.ts
+++ b/src/graphql/schemas/imagebooru.ts
@@ -12,6 +12,8 @@ export const ImageBooruSchemas = gql`
         safebooru
         "konachan.net"
         konachan
+        "gelbooru.net"
+        gelbooru
     }
 
     type ImageInfo {
@@ -59,7 +61,7 @@ export const ImageBooruSchemas = gql`
     }
 `;
 
-export type BoardEngine = "danbooru" | "safebooru" | "konachan";
+export type BoardEngine = "danbooru" | "safebooru" | "konachan" | "gelbooru";
 
 export interface ImageInfo {
     w?: Nullable<number>;

--- a/src/graphql/schemas/imagebooru.ts
+++ b/src/graphql/schemas/imagebooru.ts
@@ -84,6 +84,11 @@ export interface ImageBoardResult {
     engine: BoardEngine;
 }
 
+export interface ImageBoardResults {
+    results: ImageBoardResults[] | never[];
+    total: number;
+}
+
 export interface ImageBoardParams {
     tags?: string[];
     page: number;

--- a/src/graphql/schemas/imagebooru.ts
+++ b/src/graphql/schemas/imagebooru.ts
@@ -10,6 +10,8 @@ export const ImageBooruSchemas = gql`
         danbooru
         "danbooru.donmai.us with rating:safe"
         safebooru
+        "konachan.net"
+        konachan
     }
 
     type ImageInfo {
@@ -57,7 +59,7 @@ export const ImageBooruSchemas = gql`
     }
 `;
 
-export type BoardEngine = "danbooru" | "safebooru";
+export type BoardEngine = "danbooru" | "safebooru" | "konachan";
 
 export interface ImageInfo {
     w?: Nullable<number>;
@@ -78,4 +80,10 @@ export interface ImageBoardResult {
     image_info: ImageInfo;
     extras: { [key: string]: any };
     engine: BoardEngine;
+}
+
+export interface ImageBoardParams {
+    tags?: string[];
+    page: number;
+    engine: BoardEngine[];
 }

--- a/src/graphql/schemas/imagebooru.ts
+++ b/src/graphql/schemas/imagebooru.ts
@@ -1,0 +1,79 @@
+import { gql } from "apollo-server-express";
+import { Nullable } from "../../utils/swissknife";
+
+export const ImageBooruSchemas = gql`
+    """
+    The board type or the image board name
+    """
+    enum BoardEngine {
+        "danbooru.donmai.us"
+        danbooru
+    }
+
+    type ImageInfo {
+        "The image width"
+        w: Int
+        "The image height"
+        h: Int
+        "The image extension"
+        e: String
+        "The image size in bytes (If available)"
+        s: Int
+    }
+
+    """
+    The result of the search params on the selected Image board.
+    """
+    type ImageBoardResult {
+        "The image ID"
+        id: ID!
+        "The image title"
+        title: String!
+        "The image tags"
+        tags: [String]
+        "The image meta tags (If available)"
+        meta: [String]
+        "The image artist tags (If available)"
+        artist: [String]
+        "The image source (If available)"
+        source: String
+        "The image thumbnail"
+        thumbnail: String!
+        "The image URL"
+        image_url: String!
+        "Image metadata information"
+        image_info: ImageInfo
+        "Extras data that might be omitted by the selected engine"
+        extras: JSON
+        "The board engine or type used for the image"
+        engine: BoardEngine!
+    }
+
+    type ImageBoardResults {
+        results: [ImageBoardResult]!
+        total: Int!
+    }
+`;
+
+export type BoardEngine = "danbooru";
+
+export interface ImageInfo {
+    w?: Nullable<number>;
+    h?: Nullable<number>;
+    e?: Nullable<string>;
+    s?: Nullable<number>;
+}
+
+export interface ImageBoardResult {
+    id: any;
+    title: string;
+    tags?: Nullable<string[]>;
+    meta?: Nullable<string[]>;
+    artist?: Nullable<string[]>;
+    source?: Nullable<string>;
+    thumbnail: string;
+    image_url: string;
+    image_info: ImageInfo;
+    extras: { [key: string]: any };
+    engine: BoardEngine;
+}

--- a/src/graphql/schemas/imagebooru.ts
+++ b/src/graphql/schemas/imagebooru.ts
@@ -8,12 +8,12 @@ export const ImageBooruSchemas = gql`
     enum BoardEngine {
         "danbooru.donmai.us"
         danbooru
-        "danbooru.donmai.us with rating:safe"
-        safebooru
         "konachan.net"
         konachan
         "gelbooru.net"
         gelbooru
+        "e621.net"
+        e621
     }
 
     type ImageInfo {
@@ -61,7 +61,7 @@ export const ImageBooruSchemas = gql`
     }
 `;
 
-export type BoardEngine = "danbooru" | "safebooru" | "konachan" | "gelbooru";
+export type BoardEngine = "danbooru" | "konachan" | "gelbooru" | "e621";
 
 export interface ImageInfo {
     w?: Nullable<number>;
@@ -93,4 +93,5 @@ export interface ImageBoardParams {
     tags?: string[];
     page: number;
     engine: BoardEngine[];
+    safeVersion: boolean;
 }

--- a/src/graphql/schemas/index.ts
+++ b/src/graphql/schemas/index.ts
@@ -14,54 +14,106 @@ export const v2Definitions = gql`
     type VTuberQuery {
         "Get currently live VTuber"
         live(
+            "The channel ID to be checked, this will limit result to provided channel ID"
             channel_id: [ID]
+            "The groups to be checked, this will limit result to VTuber from the group"
             groups: [String]
+            "The platform that will be checked, will limit to the selected platforms"
             platforms: [PlatformName]
+            """
+            Sort key to be used, use the key name of the result to select it, use dot notation.
+            (Note: not all of key are supported)
+            """
             sort_by: String = "timeData.startTime"
+            "Sort order"
             sort_order: SortOrder = asc
+            "Pagination cursor of next page"
             cursor: String
+            "Limit per page, maximum limit is 75"
             limit: Int = 25
         ): LivesResource
         "Get upcoming live"
         upcoming(
+            "The channel ID to be checked, this will limit result to provided channel ID"
             channel_id: [ID]
+            "The groups to be checked, this will limit result to VTuber from the group"
             groups: [String]
+            "The platform that will be checked, will limit to the selected platforms"
             platforms: [PlatformName]
+            """
+            Sort key to be used, use the key name of the result to select it, use dot notation.
+            (Note: not all of key are supported)
+            """
             sort_by: String = "timeData.startTime"
+            "Sort order"
             sort_order: SortOrder = asc
+            "The maximum time that will be returned, Unix Timestamp or UTC format (in seconds)"
             max_scheduled_time: Int
+            "Pagination cursor of next page"
             cursor: String
+            "Limit per page, maximum limit is 75"
             limit: Int = 25
         ): LivesResource
         "Get past live of Youtube livestream up-to 24 hours (before deletion from database)"
         ended(
+            "The channel ID to be checked, this will limit result to provided channel ID"
             channel_id: [ID]
+            "The groups to be checked, this will limit result to VTuber from the group"
             groups: [String]
+            "The platform that will be checked, will limit to the selected platforms"
             platforms: [PlatformName]
+            """
+            Sort key to be used, use the key name of the result to select it, use dot notation.
+            (Note: not all of key are supported)
+            """
             sort_by: String = "timeData.endTime"
+            "Sort order"
             sort_order: SortOrder = asc
+            "Pagination cursor of next page"
             cursor: String
+            "The maximum lookback past stream that will be returned, in hours (maximum is 24)"
             max_lookback: Int = 6
+            "Limit per page, maximum limit is 75"
             limit: Int = 25
         ): LivesResource @cacheControl(maxAge: 300)
         "Get uploaded video to Youtube, Twitcasting, Twitch, etc."
         videos(
+            "The channel ID to be checked, this will limit result to provided channel ID"
             channel_id: [ID]
+            "The groups to be checked, this will limit result to VTuber from the group"
             groups: [String]
+            "The platform that will be checked, will limit to the selected platforms"
             platforms: [PlatformName]
+            """
+            Sort key to be used, use the key name of the result to select it, use dot notation.
+            (Note: not all of key are supported)
+            """
             sort_by: String = "publishedAt"
+            "Sort order"
             sort_order: SortOrder = asc
+            "Pagination cursor of next page"
             cursor: String
+            "Limit per page, maximum limit is 75"
             limit: Int = 25
         ): LivesResource @cacheControl(maxAge: 1800)
         "Get a list of channel information including statistics"
         channels(
+            "The channel ID to be checked, this will limit result to provided channel ID"
             id: [ID]
+            "The groups to be checked, this will limit result to VTuber from the group"
             groups: [String]
+            "The platform that will be checked, will limit to the selected platforms"
             platforms: [PlatformName]
+            """
+            Sort key to be used, use the key name of the result to select it, use dot notation.
+            (Note: not all of key are supported)
+            """
             sort_by: String = "id"
+            "Sort order"
             sort_order: SortOrder = asc
+            "Pagination cursor of next page"
             cursor: String
+            "Limit per page, maximum limit is 75"
             limit: Int = 25
         ): ChannelsResource @cacheControl(maxAge: 1800)
         "Get a list of available groups in the database"
@@ -74,11 +126,32 @@ export const v2Definitions = gql`
     """
     type SauceQuery {
         "Find your sauce via SauceNAO"
-        saucenao(url: String!, minsim: Float = 57.5, limit: Int = 6, db_index: Int = 999): SauceResource!
+        saucenao(
+            "Image URL to find the sauce for"
+            url: String!
+            "Minimum similarity for the image"
+            minsim: Float = 57.5
+            "Maximum image that will be returned"
+            limit: Int = 6
+            "DB Index to be used, recommended to leave untoched"
+            db_index: Int = 999
+        ): SauceResource!
         "Find your sauce via IQDB"
-        iqdb(url: String!, minsim: Float = 50.0, limit: Int = 6): SauceResource!
+        iqdb(
+            "Image URL to find the sauce for"
+            url: String!
+            "Minimum similarity for the image"
+            minsim: Float = 50.0
+            "Maximum image that will be returned"
+            limit: Int = 6
+        ): SauceResource!
         "Find your sauce via ASCII2D"
-        ascii2d(url: String!, limit: Int = 2): SauceResource!
+        ascii2d(
+            "Image URL to find the sauce for"
+            url: String!
+            "Maximum image that will be returned"
+            limit: Int = 2
+        ): SauceResource!
     }
 
     """
@@ -87,11 +160,16 @@ export const v2Definitions = gql`
     """
     type nHentaiQuery {
         "Get information of a doujin_id"
-        info(doujin_id: ID!): nhInfoResult!
+        info("The doujin ID to see" doujin_id: ID!): nhInfoResult!
         "Search nHentai for some doujin(shi)"
-        search(query: String!, page: Int = 1): nhSearchResult!
+        search(
+            "Query params, support advanced params too!"
+            query: String!
+            "The page you want to see"
+            page: Int = 1
+        ): nhSearchResult!
         "Get latest nHentai doujin(shi)"
-        latest(page: Int = 1): nhSearchResult!
+        latest("The page you want to see" page: Int = 1): nhSearchResult!
     }
 
     """
@@ -99,15 +177,36 @@ export const v2Definitions = gql`
     """
     type ImageBoardQuery {
         "Search the Image board with the tags params for your search query."
-        search(tags: [String], page: Int = 1, engine: [BoardEngine!]! = [danbooru]): ImageBoardResults!
+        search(
+            "The tags that will be searched, limit of 2 for now"
+            tags: [String]
+            "The page you want to see"
+            page: Int = 1
+            "The engine/backend to use"
+            engine: [BoardEngine!]! = [danbooru, konachan, gelbooru]
+        ): ImageBoardResults!
         "Search the Image board with the tags params for your search query, this will randomized the order."
-        random(tags: [String], page: Int = 1, engine: [BoardEngine!]! = [danbooru]): ImageBoardResults!
+        random(
+            "The tags that will be searched, limit of 2 for now"
+            tags: [String]
+            "The page you want to see"
+            page: Int = 1
+            "The engine/backend to use"
+            engine: [BoardEngine!]! = [danbooru, konachan, gelbooru]
+        ): ImageBoardResults!
     }
 
+    """
+    ihateani.me API Query
+    """
     type Query {
+        "VTuber API Query"
         vtuber: VTuberQuery!
+        "Sauce API Query"
         sauce: SauceQuery!
+        "nHentai API Query"
         nhentai: nHentaiQuery!
+        "Image Board Query"
         imagebooru: ImageBoardQuery!
     }
 `;

--- a/src/graphql/schemas/index.ts
+++ b/src/graphql/schemas/index.ts
@@ -3,6 +3,7 @@ import { gql } from "apollo-server-express";
 export * from "./vtapi";
 export * from "./saucefinder";
 export * from "./nh";
+export * from "./imagebooru";
 
 export const v2Definitions = gql`
     """
@@ -90,9 +91,15 @@ export const v2Definitions = gql`
         latest(page: Int = 1): nhSearchResult!
     }
 
+    type ImageBoardQuery {
+        search(tags: [String], engine: [BoardEngine] = [danbooru]): ImageBoardResults!
+        random(tags: [String], engine: [BoardEngine] = [danbooru]): ImageBoardResults!
+    }
+
     type Query {
         vtuber: VTuberQuery!
         sauce: SauceQuery!
         nhentai: nHentaiQuery!
+        imagebooru: ImageBoardQuery!
     }
 `;

--- a/src/graphql/schemas/index.ts
+++ b/src/graphql/schemas/index.ts
@@ -86,14 +86,22 @@ export const v2Definitions = gql`
     This is a drop in replacement for /v1/nh, except the Image route.
     """
     type nHentaiQuery {
+        "Get information of a doujin_id"
         info(doujin_id: ID!): nhInfoResult!
+        "Search nHentai for some doujin(shi)"
         search(query: String!, page: Int = 1): nhSearchResult!
+        "Get latest nHentai doujin(shi)"
         latest(page: Int = 1): nhSearchResult!
     }
 
+    """
+    Query through a collection of Image Board/Booru website.
+    """
     type ImageBoardQuery {
-        search(tags: [String], engine: [BoardEngine!]! = [danbooru]): ImageBoardResults!
-        random(tags: [String], engine: [BoardEngine!]! = [danbooru]): ImageBoardResults!
+        "Search the Image board with the tags params for your search query."
+        search(tags: [String], page: Int = 1, engine: [BoardEngine!]! = [danbooru]): ImageBoardResults!
+        "Search the Image board with the tags params for your search query, this will randomized the order."
+        random(tags: [String], page: Int = 1, engine: [BoardEngine!]! = [danbooru]): ImageBoardResults!
     }
 
     type Query {

--- a/src/graphql/schemas/index.ts
+++ b/src/graphql/schemas/index.ts
@@ -92,8 +92,8 @@ export const v2Definitions = gql`
     }
 
     type ImageBoardQuery {
-        search(tags: [String], engine: [BoardEngine] = [danbooru]): ImageBoardResults!
-        random(tags: [String], engine: [BoardEngine] = [danbooru]): ImageBoardResults!
+        search(tags: [String], engine: [BoardEngine!]! = [danbooru]): ImageBoardResults!
+        random(tags: [String], engine: [BoardEngine!]! = [danbooru]): ImageBoardResults!
     }
 
     type Query {

--- a/src/graphql/schemas/index.ts
+++ b/src/graphql/schemas/index.ts
@@ -183,7 +183,9 @@ export const v2Definitions = gql`
             "The page you want to see"
             page: Int = 1
             "The engine/backend to use"
-            engine: [BoardEngine!]! = [danbooru, konachan, gelbooru]
+            engine: [BoardEngine!]! = [danbooru, konachan, gelbooru, e621]
+            "Force safe result or not (rating:safe)"
+            safeVersion: Boolean! = false
         ): ImageBoardResults!
         "Search the Image board with the tags params for your search query, this will randomized the order."
         random(
@@ -192,7 +194,9 @@ export const v2Definitions = gql`
             "The page you want to see"
             page: Int = 1
             "The engine/backend to use"
-            engine: [BoardEngine!]! = [danbooru, konachan, gelbooru]
+            engine: [BoardEngine!]! = [danbooru, konachan, gelbooru, e621]
+            "Force safe result or not (rating:safe)"
+            safeVersion: Boolean! = false
         ): ImageBoardResults!
     }
 

--- a/src/graphql/schemas/nh.ts
+++ b/src/graphql/schemas/nh.ts
@@ -1,55 +1,107 @@
 import { gql } from "apollo-server-express";
 
 export const nHGQLSchemas = gql`
+    """
+    The doujin title data
+    """
     type nhTitle {
+        "A simplified or shortened version of the original title"
         simple: String!
+        "English title if applicable"
         english: String!
+        "Japanese title if applicable"
         japanese: String
     }
 
+    """
+    Image information of a page or thumbnail
+    """
     type nhImage {
+        "The image type, must be 'image' or 'thumbnail'"
         type: String!
+        "The proxied URL of the image"
         url: String!
+        "The original nHentai URL of the image"
         original_url: String!
+        "Image sizes, Format: [width, height]"
         sizes: [Int]
     }
 
+    """
+    The per-tag information
+    """
     type nhTag {
+        "The tag name"
         name: String!
+        "How many doujin there are tagged the same as this"
         amount: Int
     }
 
+    """
+    Doujin tags data
+    """
     type nhTags {
+        "Artist tag data"
         artists: [nhTag]
+        "Categories tag data"
         categories: [nhTag]
+        "Groups tag data"
         groups: [nhTag]
+        "Languages tag data (If translated and such)"
         languages: [nhTag]
+        "The 'tags' tag data"
         tags: [nhTag]
+        "Parodies tag data"
         parodies: [nhTag]
+        "Characters tag data"
         characters: [nhTag]
     }
 
+    """
+    A Doujin Information
+    """
     type nhInfoResult {
+        "The doujin code"
         id: ID!
+        "Media ID for the doujin, used internally for image"
         media_id: String
+        "The doujin title"
         title: nhTitle!
+        "The cover art or thumbnail or first image"
         cover_art: nhImage!
+        "The tags"
         tags: nhTags!
+        "Images list of the doujin"
         images: [nhImage!]!
+        "The URL of the page"
         url: String!
+        "Publishing or uploaded time"
         publishedAt: DateTime!
+        "Total favorites by user"
         favorites: Int
+        "Total pages"
         total_pages: Int!
     }
 
+    """
+    Page information used for paginating between page
+    """
     type nhPageInfo {
+        "Current page"
         current: Int!
+        "Total available page"
         total: Int!
     }
 
+    """
+    Search results of the provided query
+    """
     type nhSearchResult {
+        "Provided query"
         query: String
+        "The results of it"
         results: [nhInfoResult!]
+        "Page information for paginating"
         pageInfo: nhPageInfo!
     }
 `;

--- a/src/graphql/schemas/saucefinder.ts
+++ b/src/graphql/schemas/saucefinder.ts
@@ -49,6 +49,9 @@ export const SauceAPIGQL = gql`
         indexer: String
     }
 
+    """
+    The sauce results of the provided image
+    """
     type SauceResource {
         "Total matches"
         _total: Int!

--- a/src/graphql/schemas/vtapi.ts
+++ b/src/graphql/schemas/vtapi.ts
@@ -39,10 +39,15 @@ export const VTAPIv2 = gql`
     The Platform the stream was running on, its self-explanatory
     """
     enum PlatformName {
+        "youtube.com"
         youtube
+        "bilibili.com"
         bilibili
+        "twitch.tv"
         twitch
+        "twitcasting.tv"
         twitcasting
+        "mildom.com"
         mildom
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import moment from "moment-timezone";
 import mongoose from "mongoose";
 import path from "path";
 import { altairExpress } from "altair-express-middleware";
+import { readFileSync } from "fs";
 
 import * as Logger from "./utils/logger";
 import * as Routes from "./routes";
@@ -15,7 +16,6 @@ import { GQLAPIv2Server } from "./graphql";
 import htmlMinifier from "./utils/minifier";
 import { capitalizeIt, is_none } from "./utils/swissknife";
 
-import changelog from "./changelog.json";
 import config from "./config";
 import packageJson from "../package.json";
 
@@ -113,8 +113,9 @@ app.get("/", (_, res) => {
 });
 
 app.get("/changelog", (_, res) => {
+    const CHANGELOGS_FILE = readFileSync(path.join(__dirname, "changelog.json")).toString();
     res.render("changelog", {
-        CHANGELOGS: changelog,
+        CHANGELOGS: JSON.parse(CHANGELOGS_FILE),
     });
 });
 

--- a/src/utils/imagebooru/base.ts
+++ b/src/utils/imagebooru/base.ts
@@ -79,10 +79,42 @@ class ImageBoard<TResult extends AnyDict, TMapping extends AnyDict> {
                             sep = elem[2];
                             elem = elem.substring(5);
                         }
-                        let data = _.get(main_data, elem);
+                        let convType;
+                        if (typeof value === "string" && value.includes("##")) {
+                            [value, convType] = value.split("##");
+                            convType = convType.toLowerCase();
+                        }
+                        let selectFallback;
+                        if (typeof value === "string" && value.includes("||")) {
+                            selectFallback = value.split("||");
+                        }
+                        let data;
+                        if (typeof selectFallback !== "undefined") {
+                            for (let i = 0; i < selectFallback.length; i++) {
+                                data = _.get(main_data, selectFallback[i]);
+                                if (!is_none(data)) {
+                                    break;
+                                }
+                                if (typeof data === "string") {
+                                    if (data !== "" || data !== " ") {
+                                        break;
+                                    }
+                                }
+                            }
+                        } else {
+                            data = _.get(main_data, value);
+                        }
                         if (is_none(data)) {
                             collectVal.push("");
                             return;
+                        }
+                        if (typeof convType === "string") {
+                            if (convType === "float" || convType === "int") {
+                                // @ts-ignore
+                                data = parseFloat(data);
+                            } else if (convType === "str") {
+                                data = data.toString();
+                            }
                         }
                         if (typeof sep === "string" && typeof data === "string") {
                             data = data.split(sep);
@@ -96,9 +128,41 @@ class ImageBoard<TResult extends AnyDict, TMapping extends AnyDict> {
                         sep = value[2];
                         value = value.substring(5);
                     }
-                    let data = _.get(main_data, value);
+                    let convType;
+                    if (typeof value === "string" && value.includes("##")) {
+                        [value, convType] = value.split("##");
+                        convType = convType.toLowerCase();
+                    }
+                    let selectFallback;
+                    if (typeof value === "string" && value.includes("||")) {
+                        selectFallback = value.split("||");
+                    }
+                    let data;
+                    if (typeof selectFallback !== "undefined") {
+                        for (let i = 0; i < selectFallback.length; i++) {
+                            data = _.get(main_data, selectFallback[i]);
+                            if (!is_none(data)) {
+                                break;
+                            }
+                            if (typeof data === "string") {
+                                if (data !== "" || data !== " ") {
+                                    break;
+                                }
+                            }
+                        }
+                    } else {
+                        data = _.get(main_data, value);
+                    }
                     if (is_none(data)) {
                         return "";
+                    }
+                    if (typeof convType === "string") {
+                        if (convType === "float" || convType === "int") {
+                            // @ts-ignore
+                            data = parseFloat(data);
+                        } else if (convType === "str") {
+                            data = data.toString();
+                        }
                     }
                     if (typeof sep === "string" && typeof data === "string") {
                         data = data.split(sep);

--- a/src/utils/imagebooru/base.ts
+++ b/src/utils/imagebooru/base.ts
@@ -1,0 +1,131 @@
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, Method } from "axios";
+
+import { is_none } from "../swissknife";
+
+import packageJson from "../../../package.json";
+import { Logger } from "winston";
+import _ from "lodash";
+
+interface AnyDict {
+    [key: string]: any;
+}
+
+export class ImageBoard<TResult extends AnyDict, TMapping extends AnyDict> {
+    protected sesi: AxiosInstance;
+    protected mappings!: TMapping;
+    protected logger!: Logger;
+
+    constructor(BASE_URL: string) {
+        this.sesi = axios.create({
+            headers: {
+                "User-Agent": `ihaapi-ts/${packageJson["version"]} (https://github.com/ihateani-me/ihaapi-ts)`,
+            },
+            baseURL: BASE_URL,
+        });
+    }
+
+    protected async request<R extends { [key: string]: any }>(
+        method: Method,
+        path: string,
+        extraArgs: AxiosRequestConfig
+    ): Promise<[R, number]> {
+        const defaults: AxiosRequestConfig = {
+            method: method,
+            url: path,
+        };
+        const mergedOptions = Object.assign({}, defaults, extraArgs);
+        let resp: AxiosResponse<R>;
+        try {
+            resp = await this.sesi.request<R>(mergedOptions);
+        } catch (err) {
+            if (err.response) {
+                return [err.response.data, err.response.status];
+            }
+            // @ts-ignore
+            return [{}, 503];
+        }
+        return [resp.data, resp.status];
+    }
+    async parseJson<R extends { [key: string]: any }>(dataset: R | R[]): Promise<TResult[]> {
+        const logger = this.logger.child({ fn: "parseJson" });
+        let properDataset: R[];
+        if (!Array.isArray(dataset)) {
+            properDataset = [dataset];
+        } else {
+            properDataset = dataset;
+        }
+
+        async function internalMapper(main_data: R, mappings: TMapping): Promise<TResult> {
+            function mapIt(value: any): any | any[] {
+                if (Array.isArray(value)) {
+                    const collectVal: any[] = [];
+                    value.forEach((elem) => {
+                        let sep;
+                        if (typeof elem === "string" && elem.startsWith("++")) {
+                            sep = elem[2];
+                            elem = elem.substring(5);
+                        }
+                        let data = _.get(main_data, elem);
+                        if (is_none(data)) {
+                            collectVal.push("");
+                            return;
+                        }
+                        if (typeof sep === "string" && typeof data === "string") {
+                            data = data.split(sep);
+                        }
+                        collectVal.push(data);
+                    });
+                    return collectVal;
+                } else {
+                    let sep;
+                    if (typeof value === "string" && value.startsWith("++")) {
+                        sep = value[2];
+                        value = value.substring(5);
+                    }
+                    let data = _.get(main_data, value);
+                    if (is_none(data)) {
+                        return "";
+                    }
+                    if (typeof sep === "string" && typeof data === "string") {
+                        data = data.split(sep);
+                    }
+                    return data;
+                }
+            }
+
+            // @ts-ignore
+            const finalized: TResult = {};
+            const isObject = (val: any) => typeof val === "object" && !Array.isArray(val);
+            const recurseIt = (obj = {}, prevKey: string[] = []) => {
+                // @ts-ignore
+                Object.entries(obj).reduce((_prod, [key, value]) => {
+                    const path = _.concat(prevKey, key);
+                    isObject(value)
+                        ? recurseIt(value as any, prevKey.concat(key))
+                        : _.set(finalized, path.join("."), mapIt(value));
+                    return key;
+                }, []);
+            };
+            recurseIt(mappings);
+            return finalized;
+        }
+
+        const tasksManager = properDataset.map((data) =>
+            internalMapper(data, this.mappings)
+                .then((res) => {
+                    return res;
+                })
+                .catch(
+                    (err): TResult => {
+                        logger.error("Failed to parse some data, ignoring...");
+                        console.error(err);
+                        // @ts-ignore
+                        return {};
+                    }
+                )
+        );
+
+        const finalized = await Promise.all(tasksManager);
+        return finalized;
+    }
+}

--- a/src/utils/imagebooru/base.ts
+++ b/src/utils/imagebooru/base.ts
@@ -10,7 +10,14 @@ interface AnyDict {
     [key: string]: any;
 }
 
-export class ImageBoard<TResult extends AnyDict, TMapping extends AnyDict> {
+export interface ImageBoardResultsBase<TRes> {
+    results: TRes[];
+    total_data: number;
+    engine: string;
+    isError: boolean;
+}
+
+class ImageBoard<TResult extends AnyDict, TMapping extends AnyDict> {
     protected sesi: AxiosInstance;
     protected mappings!: TMapping;
     protected logger!: Logger;
@@ -128,4 +135,12 @@ export class ImageBoard<TResult extends AnyDict, TMapping extends AnyDict> {
         const finalized = await Promise.all(tasksManager);
         return finalized;
     }
+}
+
+export abstract class ImageBoardBase<TRes extends AnyDict, TMap extends AnyDict> extends ImageBoard<
+    TRes,
+    TMap
+> {
+    abstract search(query: string[]): Promise<ImageBoardResultsBase<TRes>>;
+    abstract random(query: string[]): Promise<ImageBoardResultsBase<TRes>>;
 }

--- a/src/utils/imagebooru/danbooru.ts
+++ b/src/utils/imagebooru/danbooru.ts
@@ -104,10 +104,11 @@ export class DanbooruBoard extends ImageBoardBase<DanbooruResult, DanbooruMappin
 
     async random(query: string[] = [], page = 1): Promise<ImageBoardResultsBase<DanbooruResult>> {
         query = query.filter((tag) => typeof tag === "string" && tag.length > 0 && tag);
+        query = query.map((tag) => tag.replace(" ", "_").toLowerCase());
+        query = query.filter((tag) => !tag.startsWith("order:")); // remove any order: tag
         if (!query.includes("order:random")) {
             query.push("order:random");
         }
-        query = query.map((tag) => tag.replace(" ", "_").toLowerCase());
         return await this.search(query, page);
     }
 }

--- a/src/utils/imagebooru/danbooru.ts
+++ b/src/utils/imagebooru/danbooru.ts
@@ -1,0 +1,115 @@
+import { ImageBoard } from "./base";
+
+import { logger as MainLogger } from "../logger";
+
+interface DanbooruResult {
+    id?: string;
+    title?: string;
+    tags?: string[];
+    meta?: string[];
+    artist?: string[];
+    source?: string;
+    thumbnail: string;
+    image_url: string;
+    image_info: {
+        w?: number | string;
+        h?: number | string;
+        e?: string | string;
+        s?: number | string;
+    };
+}
+
+interface DanbooruMapping {
+    id: string;
+    title: string;
+    tags: string;
+    meta: string;
+    artist: string;
+    source: string;
+    thumbnail: string;
+    image_url: string;
+    image_info: {
+        w: string;
+        h: string;
+        e: string;
+        s: string;
+    };
+}
+
+interface DanbooruSearch {
+    results: DanbooruResult[];
+    total_data: number;
+    engine: string;
+    isError: boolean;
+}
+
+export class DanbooruBoard extends ImageBoard<DanbooruResult, DanbooruMapping> {
+    private familyFriendly: boolean;
+
+    constructor(safe_version = false) {
+        super("https://danbooru.donmai.us");
+        this.familyFriendly = safe_version;
+        this.logger = MainLogger.child({ cls: "DanbooruBoard" });
+        this.mappings = {
+            id: "id",
+            title: "tag_string_character",
+            tags: "++ ++tag_string",
+            meta: "++ ++tag_string_meta",
+            artist: "++ ++tag_string_artist",
+            source: "source",
+            thumbnail: "preview_file_url",
+            image_url: "file_url",
+            image_info: { w: "image_width", h: "image_height", e: "file_ext", s: "file_size" },
+        };
+    }
+
+    async search(query: string[] = []): Promise<DanbooruSearch> {
+        const params: { [key: string]: any } = {
+            limit: 10,
+        };
+        if (this.familyFriendly) {
+            const redoneTags: string[] = [];
+            query.forEach((tag) => {
+                if (tag.includes("rating:")) {
+                    return;
+                }
+                redoneTags.push(tag);
+            });
+            redoneTags.push("rating:safe");
+            query = redoneTags;
+        }
+        query = query.filter((tag) => typeof tag === "string" && tag.length > 0 && tag);
+        if (query.length > 0) {
+            params["tags"] = query.join("+");
+        }
+        const [results, status_code] = await this.request("get", "/posts.json", {
+            params: params,
+        });
+        let resultsFinal: DanbooruSearch;
+        if (status_code === 200) {
+            const parsedResults = await this.parseJson(results);
+            resultsFinal = {
+                results: parsedResults,
+                total_data: parsedResults.length,
+                engine: "danbooru",
+                isError: false,
+            };
+        } else {
+            resultsFinal = {
+                results: [],
+                total_data: 0,
+                engine: "danbooru",
+                isError: true,
+            };
+        }
+        return resultsFinal;
+    }
+
+    async random(query: string[] = []): Promise<DanbooruSearch> {
+        query = query.filter((tag) => typeof tag === "string" && tag.length > 0 && tag);
+        if (!query.includes("order:random")) {
+            query.push("order:random");
+        }
+        return await this.search(query);
+    }
+}

--- a/src/utils/imagebooru/danbooru.ts
+++ b/src/utils/imagebooru/danbooru.ts
@@ -1,4 +1,4 @@
-import { ImageBoardBase, ImageBoardResultsBase } from "./base";
+import { AnyDict, ImageBoardBase, ImageBoardResultsBase } from "./base";
 
 import { logger as MainLogger } from "../logger";
 import { numMoreThan } from "../swissknife";
@@ -79,7 +79,7 @@ export class DanbooruBoard extends ImageBoardBase<DanbooruResult, DanbooruMappin
         if (query.length > 0) {
             params["tags"] = query.join("+");
         }
-        const [results, status_code] = await this.request("get", "/posts.json", {
+        const [results, status_code] = await this.request<AnyDict>("get", "/posts.json", {
             params: params,
         });
         let resultsFinal;

--- a/src/utils/imagebooru/danbooru.ts
+++ b/src/utils/imagebooru/danbooru.ts
@@ -88,26 +88,26 @@ export class DanbooruBoard extends ImageBoardBase<DanbooruResult, DanbooruMappin
             resultsFinal = {
                 results: parsedResults,
                 total_data: parsedResults.length,
-                engine: "danbooru",
+                engine: this.familyFriendly ? "safebooru" : "danbooru",
                 isError: false,
             };
         } else {
             resultsFinal = {
                 results: [],
                 total_data: 0,
-                engine: "danbooru",
+                engine: this.familyFriendly ? "safebooru" : "danbooru",
                 isError: true,
             };
         }
         return resultsFinal;
     }
 
-    async random(query: string[] = []): Promise<ImageBoardResultsBase<DanbooruResult>> {
+    async random(query: string[] = [], page = 1): Promise<ImageBoardResultsBase<DanbooruResult>> {
         query = query.filter((tag) => typeof tag === "string" && tag.length > 0 && tag);
         if (!query.includes("order:random")) {
             query.push("order:random");
         }
         query = query.map((tag) => tag.replace(" ", "_").toLowerCase());
-        return await this.search(query);
+        return await this.search(query, page);
     }
 }

--- a/src/utils/imagebooru/danbooru.ts
+++ b/src/utils/imagebooru/danbooru.ts
@@ -46,8 +46,8 @@ export class DanbooruBoard extends ImageBoardBase<DanbooruResult, DanbooruMappin
         this.logger = MainLogger.child({ cls: "DanbooruBoard" });
         this.mappings = {
             id: "id",
-            title: "tag_string_character",
-            tags: "++ ++tag_string",
+            title: "tag_string_character||tag_string_copyright||tag_string_general||tag_string",
+            tags: "++ ++tag_string_general||tag_string",
             meta: "++ ++tag_string_meta",
             artist: "++ ++tag_string_artist",
             source: "source",

--- a/src/utils/imagebooru/danbooru.ts
+++ b/src/utils/imagebooru/danbooru.ts
@@ -63,6 +63,7 @@ export class DanbooruBoard extends ImageBoardBase<DanbooruResult, DanbooruMappin
             limit: 15,
             page: page,
         };
+        query = this.normalizeTags(query);
         if (this.familyFriendly) {
             const redoneTags: string[] = [];
             query.forEach((tag) => {
@@ -74,8 +75,6 @@ export class DanbooruBoard extends ImageBoardBase<DanbooruResult, DanbooruMappin
             redoneTags.push("rating:safe");
             query = redoneTags;
         }
-        query = query.filter((tag) => typeof tag === "string" && tag.length > 0 && tag);
-        query = query.map((tag) => tag.replace(" ", "_").toLowerCase());
         if (query.length > 0) {
             params["tags"] = query.join("+");
         }
@@ -103,8 +102,7 @@ export class DanbooruBoard extends ImageBoardBase<DanbooruResult, DanbooruMappin
     }
 
     async random(query: string[] = [], page = 1): Promise<ImageBoardResultsBase<DanbooruResult>> {
-        query = query.filter((tag) => typeof tag === "string" && tag.length > 0 && tag);
-        query = query.map((tag) => tag.replace(" ", "_").toLowerCase());
+        query = this.normalizeTags(query);
         query = query.filter((tag) => !tag.startsWith("order:")); // remove any order: tag
         if (!query.includes("order:random")) {
             query.push("order:random");

--- a/src/utils/imagebooru/e621.ts
+++ b/src/utils/imagebooru/e621.ts
@@ -1,0 +1,118 @@
+import { AnyDict, ImageBoardBase, ImageBoardResultsBase } from "./base";
+
+import { logger as MainLogger } from "../logger";
+import { numMoreThan } from "../swissknife";
+
+interface E621Result {
+    id?: string;
+    title?: string;
+    tags?: string[];
+    meta?: string[];
+    artist?: string[];
+    source?: string;
+    thumbnail: string;
+    image_url: string;
+    image_info: {
+        w?: number | string;
+        h?: number | string;
+        e?: string;
+        s?: number | string;
+    };
+}
+
+interface E621Mapping {
+    id: string;
+    title: string;
+    tags: string;
+    meta: string;
+    artist: string;
+    source: string;
+    thumbnail: string;
+    image_url: string;
+    image_info: {
+        w: string;
+        h: string;
+        e: string;
+        s: string;
+    };
+}
+
+export class E621Board extends ImageBoardBase<E621Result, E621Mapping> {
+    private familyFriendly: boolean;
+
+    constructor(safe_version = false) {
+        super("https://e621.net");
+        this.familyFriendly = safe_version;
+        this.logger = MainLogger.child({ cls: "E621Board" });
+        this.mappings = {
+            id: "id",
+            title: "description||tags.general",
+            tags: "tags.general",
+            meta: "tags.meta",
+            artist: "tags.artist",
+            source: "sources.0",
+            thumbnail: "preview.url",
+            image_url: "file.url",
+            image_info: { w: "file.width", h: "file.height", e: "file.ext", s: "file.size" },
+        };
+    }
+
+    async search(query: string[] = [], page = 1): Promise<ImageBoardResultsBase<E621Result>> {
+        page = numMoreThan(page, 1);
+        const params: { [key: string]: any } = {
+            limit: 15,
+            page: page,
+        };
+        query = this.normalizeTags(query);
+        if (this.familyFriendly) {
+            const redoneTags: string[] = [];
+            query.forEach((tag) => {
+                if (tag.includes("rating:")) {
+                    return;
+                }
+                redoneTags.push(tag);
+            });
+            redoneTags.push("rating:safe");
+            query = redoneTags;
+        }
+        if (query.length > 0) {
+            params["tags"] = query.join("+");
+        }
+        const [results, status_code] = await this.request<AnyDict>("get", "/posts.json", {
+            params: params,
+        });
+        let resultsFinal;
+        if (status_code === 200) {
+            let parsedResults = await this.parseJson(results["posts"]);
+            parsedResults = parsedResults.map((res) => {
+                if (Array.isArray(res.title)) {
+                    res.title = res.title.join(" ");
+                }
+                return res;
+            });
+            resultsFinal = {
+                results: parsedResults,
+                total_data: parsedResults.length,
+                engine: "e621",
+                isError: false,
+            };
+        } else {
+            resultsFinal = {
+                results: [],
+                total_data: 0,
+                engine: "e621",
+                isError: true,
+            };
+        }
+        return resultsFinal;
+    }
+
+    async random(query: string[] = []): Promise<ImageBoardResultsBase<E621Result>> {
+        query = this.normalizeTags(query);
+        query = query.filter((tag) => !tag.startsWith("order:")); // remove any order: tag
+        if (!query.includes("order:random")) {
+            query.push("order:random");
+        }
+        return await this.search(query);
+    }
+}

--- a/src/utils/imagebooru/gelbooru.ts
+++ b/src/utils/imagebooru/gelbooru.ts
@@ -101,10 +101,11 @@ export class GelbooruBoard extends ImageBoardBase<GelbooruResult, GelbooruMappin
 
     async random(query: string[] = [], page = 1): Promise<ImageBoardResultsBase<GelbooruResult>> {
         query = query.filter((tag) => typeof tag === "string" && tag.length > 0 && tag);
+        query = query.map((tag) => tag.replace(" ", "_").toLowerCase());
+        query = query.filter((tag) => !tag.startsWith("order:")); // remove any order: tag
         if (!query.includes("order:random")) {
             query.push("order:random");
         }
-        query = query.map((tag) => tag.replace(" ", "_").toLowerCase());
         return await this.search(query, page);
     }
 }

--- a/src/utils/imagebooru/gelbooru.ts
+++ b/src/utils/imagebooru/gelbooru.ts
@@ -42,12 +42,12 @@ export class GelbooruBoard extends ImageBoardBase<GelbooruResult, GelbooruMappin
         this.logger = MainLogger.child({ cls: "GelbooruBoard" });
         this.mappings = {
             id: "id",
-            title: "tags",
+            title: "title||tags",
             tags: "++ ++tags",
             source: "source",
             thumbnail: "preview_url",
             image_url: "file_url",
-            image_info: { w: "width", h: "height" },
+            image_info: { w: "width##int", h: "height##int" },
         };
         this.apiKey =
             typeof config["imageboard"]["gelbooru"]["api_key"] === "string"

--- a/src/utils/imagebooru/gelbooru.ts
+++ b/src/utils/imagebooru/gelbooru.ts
@@ -1,0 +1,110 @@
+import { ImageBoardBase, ImageBoardResultsBase } from "./base";
+
+import { logger as MainLogger } from "../logger";
+import { numMoreThan } from "../swissknife";
+
+import config from "../../config";
+
+interface GelbooruResult {
+    id?: string;
+    title?: string;
+    tags?: string[];
+    source?: string;
+    thumbnail: string;
+    image_url: string;
+    image_info: {
+        w?: number | string;
+        h?: number | string;
+        e?: string | string;
+        s?: number | string;
+    };
+}
+
+interface GelbooruMapping {
+    id: string;
+    title: string;
+    tags: string;
+    source: string;
+    thumbnail: string;
+    image_url: string;
+    image_info: {
+        w: string;
+        h: string;
+    };
+}
+
+export class GelbooruBoard extends ImageBoardBase<GelbooruResult, GelbooruMapping> {
+    private apiKey: string;
+    private userId: string;
+
+    constructor() {
+        super("https://gelbooru.com");
+        this.logger = MainLogger.child({ cls: "GelbooruBoard" });
+        this.mappings = {
+            id: "id",
+            title: "tags",
+            tags: "++ ++tags",
+            source: "source",
+            thumbnail: "preview_url",
+            image_url: "file_url",
+            image_info: { w: "width", h: "height" },
+        };
+        this.apiKey =
+            typeof config["imageboard"]["gelbooru"]["api_key"] === "string"
+                ? config["imageboard"]["gelbooru"]["api_key"]
+                : "anonymous";
+        this.userId =
+            typeof config["imageboard"]["gelbooru"]["user_id"] === "string"
+                ? config["imageboard"]["gelbooru"]["user_id"]
+                : "9455";
+    }
+
+    async search(query: string[] = [], page = 1): Promise<ImageBoardResultsBase<GelbooruResult>> {
+        page = numMoreThan(page, 1);
+        const params: { [key: string]: any } = {
+            limit: 15,
+            pid: page,
+            page: "dapi",
+            s: "post",
+            q: "index",
+            api_key: this.apiKey,
+            user_id: this.userId,
+        };
+        query = query.filter((tag) => typeof tag === "string" && tag.length > 0 && tag);
+        query = query.map((tag) => tag.replace(" ", "_").toLowerCase());
+        if (query.length > 0) {
+            params["tags"] = query.join("+");
+        }
+        const [results, status_code] = await this.request<string>("get", "/index.php", {
+            params: params,
+        });
+        let resultsFinal;
+        if (status_code === 200) {
+            const convertedXMLs = await this.xmlToJSON(results, "posts.post");
+            const parsedResults = await this.parseJson(convertedXMLs);
+            resultsFinal = {
+                results: parsedResults,
+                total_data: parsedResults.length,
+                engine: "gelbooru",
+                isError: false,
+            };
+        } else {
+            resultsFinal = {
+                results: [],
+                total_data: 0,
+                engine: "gelbooru",
+                isError: true,
+            };
+        }
+        return resultsFinal;
+    }
+
+    async random(query: string[] = [], page = 1): Promise<ImageBoardResultsBase<GelbooruResult>> {
+        query = query.filter((tag) => typeof tag === "string" && tag.length > 0 && tag);
+        if (!query.includes("order:random")) {
+            query.push("order:random");
+        }
+        query = query.map((tag) => tag.replace(" ", "_").toLowerCase());
+        return await this.search(query, page);
+    }
+}

--- a/src/utils/imagebooru/index.ts
+++ b/src/utils/imagebooru/index.ts
@@ -1,1 +1,2 @@
 export * from "./danbooru";
+export * from "./konachan";

--- a/src/utils/imagebooru/index.ts
+++ b/src/utils/imagebooru/index.ts
@@ -1,2 +1,3 @@
 export * from "./danbooru";
 export * from "./konachan";
+export * from "./gelbooru";

--- a/src/utils/imagebooru/index.ts
+++ b/src/utils/imagebooru/index.ts
@@ -1,0 +1,1 @@
+export * from "./danbooru";

--- a/src/utils/imagebooru/index.ts
+++ b/src/utils/imagebooru/index.ts
@@ -1,3 +1,4 @@
 export * from "./danbooru";
 export * from "./konachan";
 export * from "./gelbooru";
+export * from "./e621";

--- a/src/utils/imagebooru/konachan.ts
+++ b/src/utils/imagebooru/konachan.ts
@@ -1,4 +1,4 @@
-import { ImageBoardBase, ImageBoardResultsBase } from "./base";
+import { AnyDict, ImageBoardBase, ImageBoardResultsBase } from "./base";
 
 import { logger as MainLogger } from "../logger";
 import { numMoreThan } from "../swissknife";
@@ -63,7 +63,7 @@ export class KonachanBoard extends ImageBoardBase<KonachanResult, KonachanMappin
         if (query.length > 0) {
             params["tags"] = query.join("+");
         }
-        const [results, status_code] = await this.request("get", "/post.json", {
+        const [results, status_code] = await this.request<AnyDict>("get", "/post.json", {
             params: params,
         });
         let resultsFinal;

--- a/src/utils/imagebooru/konachan.ts
+++ b/src/utils/imagebooru/konachan.ts
@@ -88,6 +88,8 @@ export class KonachanBoard extends ImageBoardBase<KonachanResult, KonachanMappin
 
     async random(query: string[] = []): Promise<ImageBoardResultsBase<KonachanResult>> {
         query = query.filter((tag) => typeof tag === "string" && tag.length > 0 && tag);
+        query = query.map((tag) => tag.replace(" ", "_").toLowerCase());
+        query = query.filter((tag) => !tag.startsWith("order:")); // remove any order: tag
         if (!query.includes("order:random")) {
             query.push("order:random");
         }

--- a/src/utils/imagebooru/konachan.ts
+++ b/src/utils/imagebooru/konachan.ts
@@ -1,0 +1,96 @@
+import { ImageBoardBase, ImageBoardResultsBase } from "./base";
+
+import { logger as MainLogger } from "../logger";
+import { numMoreThan } from "../swissknife";
+
+interface KonachanResult {
+    id?: string;
+    title?: string;
+    tags?: string[];
+    meta?: string[];
+    artist?: string[];
+    source?: string;
+    thumbnail: string;
+    image_url: string;
+    image_info: {
+        w?: number | string;
+        h?: number | string;
+        e?: string | string;
+    };
+}
+
+interface KonachanMapping {
+    id: string;
+    title: string;
+    tags: string;
+    meta: string;
+    artist: string;
+    source: string;
+    thumbnail: string;
+    image_url: string;
+    image_info: {
+        w: string;
+        h: string;
+        e: string;
+    };
+}
+
+export class KonachanBoard extends ImageBoardBase<KonachanResult, KonachanMapping> {
+    constructor() {
+        super("https://konachan.net");
+        this.logger = MainLogger.child({ cls: "KonachanBoard" });
+        this.mappings = {
+            id: "id",
+            title: "tags",
+            tags: "++ ++tags",
+            meta: "++ ++tags",
+            artist: "++ ++author",
+            source: "source",
+            thumbnail: "preview_url",
+            image_url: "file_url",
+            image_info: { w: "width", h: "height", e: "file_ext" },
+        };
+    }
+
+    async search(query: string[] = [], page = 1): Promise<ImageBoardResultsBase<KonachanResult>> {
+        page = numMoreThan(page, 1);
+        const params: { [key: string]: any } = {
+            limit: 15,
+            page: page,
+        };
+        query = query.filter((tag) => typeof tag === "string" && tag.length > 0 && tag);
+        query = query.map((tag) => tag.replace(" ", "_").toLowerCase());
+        if (query.length > 0) {
+            params["tags"] = query.join("+");
+        }
+        const [results, status_code] = await this.request("get", "/post.json", {
+            params: params,
+        });
+        let resultsFinal;
+        if (status_code === 200) {
+            const parsedResults = await this.parseJson(results);
+            resultsFinal = {
+                results: parsedResults,
+                total_data: parsedResults.length,
+                engine: "konachan",
+                isError: false,
+            };
+        } else {
+            resultsFinal = {
+                results: [],
+                total_data: 0,
+                engine: "konachan",
+                isError: true,
+            };
+        }
+        return resultsFinal;
+    }
+
+    async random(query: string[] = []): Promise<ImageBoardResultsBase<KonachanResult>> {
+        query = query.filter((tag) => typeof tag === "string" && tag.length > 0 && tag);
+        if (!query.includes("order:random")) {
+            query.push("order:random");
+        }
+        return await this.search(query);
+    }
+}

--- a/src/utils/swissknife.test.ts
+++ b/src/utils/swissknife.test.ts
@@ -258,3 +258,18 @@ describe("Generate random string and RNG", () => {
         expect(SwissKnife.generateCustomString(10, true, true)).toHaveLength(10);
     });
 });
+
+describe("Check if number more than minimum", () => {
+    it("Passed a number that is more than the minimum", () => {
+        expect(SwissKnife.numMoreThan(2)).toEqual(2);
+    });
+    it("Passed a number that is less than the minimum", () => {
+        expect(SwissKnife.numMoreThan(-1)).toEqual(0);
+    });
+    it("Passed a number that is more than the minimum (with a custom min)", () => {
+        expect(SwissKnife.numMoreThan(5, 4)).toEqual(5);
+    });
+    it("Passed a number that is less than the minimum (with a custom min)", () => {
+        expect(SwissKnife.numMoreThan(2, 4)).toEqual(4);
+    });
+});

--- a/src/utils/swissknife.test.ts
+++ b/src/utils/swissknife.test.ts
@@ -12,10 +12,19 @@ describe("Filter out empty data from Array", () => {
         expect(SwissKnife.filter_empty(["one"])).toEqual(["one"]);
     });
     test("Multiple data passed (with no empty data).", () => {
-        expect(SwissKnife.filter_empty(["one", "two", "three"])).toStrictEqual(["one", "two", "three"]);
+        expect(SwissKnife.filter_empty(["one", "two", "three", ["a"], 0, { a: 1 }])).toStrictEqual([
+            "one",
+            "two",
+            "three",
+            ["a"],
+            0,
+            { a: 1 },
+        ]);
     });
-    test("Multiple data passed (with one empty data).", () => {
-        expect(SwissKnife.filter_empty(["one", "two", "", "three"])).toStrictEqual(["one", "two", "three"]);
+    test("Multiple data passed (with empty data).", () => {
+        expect(
+            SwissKnife.filter_empty(["one", "two", "", "three", [], ["a"], 0, {}, { a: 1 }])
+        ).toStrictEqual(["one", "two", "three", ["a"], 0, { a: 1 }]);
     });
 });
 

--- a/src/utils/swissknife.ts
+++ b/src/utils/swissknife.ts
@@ -24,8 +24,20 @@ export function filter_empty(data: null | any[]): any[] {
         return [];
     }
     data.forEach((val) => {
-        if (val) {
+        if (typeof val === "string") {
+            if (val && val !== " " && val.length > 0) {
+                filtered.push(val);
+            }
+        } else if (Array.isArray(val)) {
+            if (val.length > 0) {
+                filtered.push(val);
+            }
+        } else if (typeof val === "number") {
             filtered.push(val);
+        } else if (typeof val === "object" && !Array.isArray(val)) {
+            if (Object.keys(val).length > 0) {
+                filtered.push(val);
+            }
         }
     });
     return filtered;

--- a/src/utils/swissknife.ts
+++ b/src/utils/swissknife.ts
@@ -235,3 +235,7 @@ export function generateCustomString(length = 8, includeNumbers = false, include
     }
     return generated;
 }
+
+export function numMoreThan(number: number, min: number = 0): number {
+    return number < min ? min : number;
+}

--- a/src/views/v2docs/_coverpage.md
+++ b/src/views/v2docs/_coverpage.md
@@ -2,7 +2,7 @@
 
 ![logo](/assets/img/apple-icon-152x152.png)
 
-# ihAPI <small>v2.5.0</small>
+# ihAPI <small>v2.5.1</small>
 
 > A simple API made with GraphQL
 

--- a/src/views/v2docs/_navbar.md
+++ b/src/views/v2docs/_navbar.md
@@ -3,4 +3,6 @@
   * [VTuber API](vtuberapi.md)
   * [Sauce API](sauceapi.md)
   * [nHentai API](nhentaiapi.md)
+  * [ImageBooru API](imagebooruapi.md)
   * [Pagination](pagination.md)
+  * [Subscriptions](subscription.md)

--- a/src/views/v2docs/_sidebar.md
+++ b/src/views/v2docs/_sidebar.md
@@ -4,6 +4,7 @@
   - [VTuber API](vtuberapi.md)
   - [Sauce API](sauceapi.md)
   - [nHentai API](nhentaiapi.md)
+  - [ImageBooru API](imagebooruapi.md)
   - [Pagination](pagination.md)
   - [Subscription](subscription.md)
 - [Compression](compression.md)

--- a/src/views/v2docs/homepage.md
+++ b/src/views/v2docs/homepage.md
@@ -1,7 +1,7 @@
 <h1 id="mulai-dari-sini" style="color:#c8c8c8;" align="center">
     ihaAPI v2 API
 </h1>
-<p align="center"><b>Version 2.5.0</b><br>A simple GraphQL endpoint for multiple utility</p>
+<p align="center"><b>Version 2.5.1</b><br>A simple GraphQL endpoint for multiple utility</p>
 
 # Introduction
 Welcome to ihateani.me API v2, this API use GraphQL powered by Apollo GraphQL Server.

--- a/src/views/v2docs/homepage.md
+++ b/src/views/v2docs/homepage.md
@@ -26,3 +26,8 @@ This is a wrapper for nHentai, this also includes a support of Image Proxy to by
 The Image Proxy are located in the /v1/ endpoint
 
 **See: [nHentai API](nhentaiapi.md)**
+
+## ImageBooru API {docsify-ignore}
+This is a wrapper of multiple Booru-like Image Board.
+
+**See: [ImageBooru API](imagebooruapi.md)**

--- a/src/views/v2docs/imagebooruapi.md
+++ b/src/views/v2docs/imagebooruapi.md
@@ -1,0 +1,307 @@
+# ImageBooru API
+
+An API wrapper for Booru-like Image Board (Danbooru, Gelbooru, etc.)
+
+**Supported Image Board**:
+- [Danbooru](https://danbooru.donmai.us/)
+- [Safebooru](https://danbooru.donmai.us/posts?tags=rating%3As) (Danbooru)
+- [Konachan](https://konachan.net/post)
+- [Gelbooru](https://gelbooru.com/index.php?page=post&s=list&tags=all)
+
+**Table of Contents**:
+- [Schemas](#schemas)
+  - [ImageBoardResult](#imageboardresult)
+- [Variables](#variables)
+- [Example](#example)
+
+## Schemas
+
+This is the GraphQL schemas that can be used to request to the Sauce API.
+
+You can see it more in detail in the [API References](https://api.ihateani.me/v2/gql-docs/api-references)
+
+```graphql
+imagebooru {
+    "Search the image board"
+    search {
+        total
+        results {}
+    }
+    "Search the image board, this will be randomized"
+    random {
+        total
+        results {}
+    }
+}
+```
+
+All of them use something called `ImageBoardResult` in the `results` fields.
+
+`total` is the total returned data.
+
+### ImageBoardResult
+
+```graphql
+"""
+The result of the search params on the selected Image board.
+"""
+{
+    "The image ID"
+    id: ID!
+    "The image title"
+    title: String!
+    "The image tags"
+    tags: [String]
+    "The image meta tags (If available)"
+    meta: [String]
+    "The image artist tags (If available)"
+    artist: [String]
+    "The image source (If available)"
+    source: String
+    "The image thumbnail"
+    thumbnail: String!
+    "The image URL"
+    image_url: String!
+    "Image metadata information"
+    image_info: ImageInfo
+    "Extras data that might be omitted by the selected engine"
+    extras: JSON
+    "The board engine or type used for the image"
+    engine: BoardEngine!
+}
+```
+
+`ImageInfo` contains the image `w` (width), `h` (height)<br>
+With additional `e` (extension) and `s` (size) sometimes
+
+`BoardEngine` is ENUM of the supported Image Board
+
+## Variables
+
+The Image Booru API accepts 3 variables:
+- **tags**: this will be your tags params in list (maximum of 2, excluding meta tags)
+- **page**: the page that will be returned
+- **engine**: The engiine that will be used, must be a list.
+
+**tags** can be empty
+
+## Example
+
+<!-- tabs:start -->
+
+#### ** Query Variables **
+
+In this example, we will use the Search method.
+
+```graphql
+query BooruSearch($tags:[String],$page:Int! = 1) {
+    imagebooru {
+        search(tags:$tags,engine:[danbooru,konachan,gelbooru],page:$page) {
+            results {
+                id
+                title
+                tags
+                thumbnail
+                image_url
+                source
+                engine
+            }
+            total
+        }
+    }
+}
+```
+
+We will also send this variables
+
+```json
+{
+    "tags": ["hololive"]
+}
+```
+
+#### ** Python **
+
+
+```py
+import requests
+
+sample = """query BooruSearch($tags:[String],$page:Int! = 1) {
+    imagebooru {
+        search(tags:$tags,engine:[danbooru,konachan,gelbooru],page:$page) {
+            results {
+                id
+                title
+                tags
+                thumbnail
+                image_url
+                source
+                engine
+            }
+            total
+        }
+    }
+} }
+}
+"""
+
+data = {
+    "query": sample,
+    "variables": {
+        "tags": ["hololive"]
+    }
+}
+req = requests.post("https://api.ihateani.me/v2/graphql", json=data)
+print(req.json())
+```
+
+#### ** JavaScript **
+
+```js
+let sample = `query BooruSearch($tags:[String],$page:Int! = 1) {
+    imagebooru {
+        search(tags:$tags,engine:[danbooru,konachan,gelbooru],page:$page) {
+            results {
+                id
+                title
+                tags
+                thumbnail
+                image_url
+                source
+                engine
+            }
+            total
+        }
+    }
+}`
+
+let variables = {
+    "tags": ["hololive"]
+}
+
+let url = 'https://api.ihateani.me/v2/graphql',
+    options = {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+        },
+        body: JSON.stringify({
+            query: sample,
+            variables: variables
+        })
+    };
+
+fetch(url, options).then(handleResponse)
+                    .then(handleData)
+                    .catch(handleError);
+
+function handleResponse(resp) {
+    return resp.json().then((json) => {
+        return resp.ok ? json : Promise.reject(json);
+    });
+}
+
+function handleData(data) {
+    console.log(data);
+}
+
+function handleError(err) {
+    alert("Error occured, please check dev console");
+    console.error(error);
+}
+```
+
+#### ** Response **
+
+The query request should return the following JSON response (or close to):
+
+```json
+{
+    "data": {
+        "imagebooru": {
+            "search": {
+                "total": 45,
+                "results": [
+                    {
+                        "id": "4381346",
+                        "title": "original",
+                        "tags": [
+                            "1girl",
+                            "black_hair",
+                            "black_legwear",
+                            "breasts",
+                            "brown_eyes",
+                            "cityscape",
+                            "cowboy_shot",
+                            "desk",
+                            "id_card",
+                            "indoors",
+                            "lanyard",
+                            "large_breasts",
+                            "long_hair",
+                            "long_sleeves",
+                            "monitor",
+                            "mouth_hold",
+                            "night",
+                            "office_lady",
+                            "pantyhose",
+                            "pencil_skirt",
+                            "purple_shirt",
+                            "shirt",
+                            "skirt",
+                            "solo",
+                            "torn_clothes",
+                            "torn_legwear"
+                        ],
+                        "thumbnail": "https://cdn.donmai.us/preview/3b/c3/3bc3e2a3b64b4d728925b1c43a6ab25b.jpg",
+                        "image_url": "https://danbooru.donmai.us/data/3bc3e2a3b64b4d728925b1c43a6ab25b.jpg",
+                        "source": "https://i.pximg.net/img-original/img/2021/02/26/14/20/34/88058842_p0.jpg",
+                        "engine": "danbooru"
+                    },
+                    {
+                        "id": "4381345",
+                        "title": "junko_(touhou)",
+                        "tags": [
+                            "1girl",
+                            "bangs",
+                            "black_dress",
+                            "black_headwear",
+                            "chinese_clothes",
+                            "closed_mouth",
+                            "crescent_moon",
+                            "dress",
+                            "eyebrows_behind_hair",
+                            "from_side",
+                            "headdress",
+                            "long_hair",
+                            "long_sleeves",
+                            "looking_at_viewer",
+                            "moon",
+                            "orange_hair",
+                            "red_eyes",
+                            "simple_background",
+                            "smile",
+                            "solo",
+                            "standing",
+                            "tabard",
+                            "upper_body",
+                            "white_background",
+                            "wide_sleeves"
+                        ],
+                        "thumbnail": "https://cdn.donmai.us/preview/87/70/8770b064c810d4978be27f558cd5f5a8.jpg",
+                        "image_url": "https://danbooru.donmai.us/data/8770b064c810d4978be27f558cd5f5a8.jpg",
+                        "source": "https://twitter.com/kamepan44231/status/1362787990196473857",
+                        "engine": "danbooru"
+                    },
+                    ...
+                ]
+            }
+        }
+    }
+}s
+```
+
+This results is truncated!
+
+<!-- tabs:end -->

--- a/src/views/v2docs/imagebooruapi.md
+++ b/src/views/v2docs/imagebooruapi.md
@@ -4,9 +4,9 @@ An API wrapper for Booru-like Image Board (Danbooru, Gelbooru, etc.)
 
 **Supported Image Board**:
 - [Danbooru](https://danbooru.donmai.us/)
-- [Safebooru](https://danbooru.donmai.us/posts?tags=rating%3As) (Danbooru)
 - [Konachan](https://konachan.net/post)
 - [Gelbooru](https://gelbooru.com/index.php?page=post&s=list&tags=all)
+- [E621](https://e621.net/)
 
 **Table of Contents**:
 - [Schemas](#schemas)
@@ -82,6 +82,7 @@ The Image Booru API accepts 3 variables:
 - **tags**: this will be your tags params in list (maximum of 2, excluding meta tags)
 - **page**: the page that will be returned
 - **engine**: The engiine that will be used, must be a list.
+- **safeVersion**: a boolean, set to `true` to only return "safe" version.
 
 **tags** can be empty
 

--- a/src/views/v2docs/subscription.md
+++ b/src/views/v2docs/subscription.md
@@ -1,5 +1,7 @@
 # GraphQL Subscription
 
+!> Incomplete documentation!
+
 Subscription is a GraphQL operation that use the WebSockets Protocol to send data over each other.<br>
 Essentially giving live update of changes of the API.
 


### PR DESCRIPTION
Create an API handler for multiple Image Booru

**Supported Website:**
- [x] Danbooru
- [x] Konachan
- [x] Gelbooru
- [x] E621

Will be added to v2 Endpoint (GraphQL)

Current Schemas (might be changed)
```gql
"""
The board type or the image board name
"""
enum BoardEngine {
    "danbooru.donmai.us"
    danbooru
    "danbooru.donmai.us with rating:safe"
    safebooru
    "konachan.net"
    konachan
    "gelbooru.net"
    gelbooru
}

type ImageInfo {
    "The image width"
    w: Int
    "The image height"
    h: Int
    "The image extension"
    e: String
    "The image size in bytes (If available)"
    s: Int
}

"""
The result of the search params on the selected Image board.
"""
type ImageBoardResult {
    "The image ID"
    id: ID!
    "The image title"
    title: String!
    "The image tags"
    tags: [String]
    "The image meta tags (If available)"
    meta: [String]
    "The image artist tags (If available)"
    artist: [String]
    "The image source (If available)"
    source: String
    "The image thumbnail"
    thumbnail: String!
    "The image URL"
    image_url: String!
    "Image metadata information"
    image_info: ImageInfo
    "Extras data that might be omitted by the selected engine"
    extras: JSON
    "The board engine or type used for the image"
    engine: BoardEngine!
}

type ImageBoardResults {
    results: [ImageBoardResult]!
    total: Int!
}
```