### PR TITLE
feat: add support for adding new VTuber via GraphQL mutation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,12 +60,20 @@ module.exports = {
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/no-inferrable-types": ["warn", { ignoreParameters: true }],
+        "@typescript-eslint/no-unused-vars": [
+            "warn",
+            {
+                argsIgnorePattern: "^_",
+            },
+        ],
     },
     overrides: [
         {
             files: ["**/*.js", "**/*.jsx"],
             rules: {
+                "@typescript-eslint/no-unused-vars": "off",
                 "@typescript-eslint/no-var-requires": "off",
+                "@typescript-eslint/": "off",
             },
         },
     ],

--- a/nodemon.json
+++ b/nodemon.json
@@ -9,6 +9,6 @@
         "src/assets/**/*",
         "src/views/**/*"
     ],
-    "exec": "ts-node ./src/main.ts --transpile-only",
+    "exec": "ts-node --transpile-only ./src/main.ts",
     "ext": "ts js"
 }

--- a/src/graphql/mutations/index.ts
+++ b/src/graphql/mutations/index.ts
@@ -1,0 +1,16 @@
+import {
+    mildomChannelsDataset,
+    ttvChannelDataset,
+    twcastChannelsDataset,
+    youtubeChannelDataset,
+} from "./vtuber";
+
+const VTuberMutation = {
+    // @ts-ignore
+    twitch: ttvChannelDataset,
+    twitcasting: twcastChannelsDataset,
+    mildom: mildomChannelsDataset,
+    youtube: youtubeChannelDataset,
+};
+
+export { VTuberMutation };

--- a/src/graphql/mutations/vtuber/helper/index.ts
+++ b/src/graphql/mutations/vtuber/helper/index.ts
@@ -1,0 +1,2 @@
+export * from "./mildomapi";
+export * from "./ttvapi";

--- a/src/graphql/mutations/vtuber/helper/mildomapi.ts
+++ b/src/graphql/mutations/vtuber/helper/mildomapi.ts
@@ -1,0 +1,193 @@
+import _ from "lodash";
+import moment from "moment-timezone";
+import axios, { AxiosInstance } from "axios";
+import { Logger } from "winston";
+
+import { logger as MainLogger } from "../../../../utils/logger";
+import { is_none } from "../../../../utils/swissknife";
+import { ChannelsProps, VideoProps } from "../../../../controller";
+
+interface AnyDict {
+    [key: string]: any;
+}
+
+const CHROME_UA =
+    // eslint-disable-next-line max-len
+    " Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36";
+
+export class MildomAPI {
+    private session: AxiosInstance;
+    private BASE_URL: string;
+    private logger: Logger;
+
+    constructor() {
+        this.session = axios.create({
+            headers: {
+                "User-Agent": CHROME_UA,
+            },
+        });
+
+        this.BASE_URL = "https://cloudac.mildom.com/nonolive/";
+        this.logger = MainLogger.child({ cls: "MildomAPI" });
+    }
+
+    async fetchUser(userId: string) {
+        const params = {
+            user_id: userId,
+            __location: "Japan|Tokyo",
+            __country: "",
+            __cluster: "aws_japan",
+            __platform: "web",
+            __la: "ja",
+            sfr: "pc",
+            accessToken: "",
+        };
+        const logger = this.logger.child({ fn: "fetchUser" });
+        let results;
+        try {
+            const rawResults = await this.session.get(this.BASE_URL + "gappserv/user/profileV2", {
+                params: params,
+                responseType: "json",
+            });
+            results = rawResults.data;
+        } catch (e) {
+            if (e.response) {
+                results = e.response.data;
+            } else {
+                logger.error(`Failed to fetch user ${userId}, ${e.toString()}`);
+                console.error(e);
+                results = { body: {}, code: -1, message: e.toString() };
+            }
+        }
+
+        if (results["code"] !== 0) {
+            logger.error(`An error occured when fetching user ${userId}`);
+            logger.error(`Got error ${results["code"]}, ${results["message"]}`);
+            return undefined;
+        }
+
+        // @ts-ignore
+        const properResults: ChannelsProps = {};
+        const bodyRes = _.get(results, "body", {});
+        const userInfo = _.get(bodyRes, "user_info", {});
+        if (is_none(userInfo)) {
+            logger.error(`User ID ${userId} missing required data to process`);
+            return undefined;
+        }
+
+        properResults["id"] = userInfo["my_id"];
+        properResults["name"] = userInfo["loginname"];
+        properResults["description"] = userInfo["intro"];
+        properResults["followerCount"] = userInfo["fans"];
+        properResults["level"] = userInfo["level"];
+        properResults["thumbnail"] = userInfo["avatar"];
+        properResults["platform"] = "mildom";
+        return properResults;
+    }
+
+    async fetchVideos(userId: string) {
+        let collectedVideos: AnyDict[] = [];
+        let currentPage = 1;
+        while (true) {
+            try {
+                const resp = await this.session.get(this.BASE_URL + "videocontent/profile/playbackList", {
+                    params: {
+                        __location: "Japan|Tokyo",
+                        __country: "",
+                        __cluster: "aws_japan",
+                        __platform: "web",
+                        __la: "ja",
+                        sfr: "pc",
+                        accessToken: "",
+                        user_id: userId,
+                        limit: "100",
+                        page: currentPage.toString(),
+                    },
+                    responseType: "json",
+                });
+                const res = resp.data;
+                if (res["code"] !== 0) {
+                    break;
+                }
+                const currentVideo = res["body"];
+                collectedVideos = _.concat(collectedVideos, currentVideo);
+                if (currentVideo.length !== 100) {
+                    // Break if reach max page
+                    break;
+                }
+                currentPage++;
+            } catch (e) {
+                break;
+            }
+        }
+        return collectedVideos;
+    }
+
+    async fetchLives(userId: string) {
+        const params = {
+            user_id: userId,
+            __location: "Japan|Tokyo",
+            __country: "",
+            __cluster: "aws_japan",
+            __platform: "web",
+            __la: "ja",
+            sfr: "pc",
+            accessToken: "",
+        };
+        const logger = this.logger.child({ fn: "fetchLives" });
+        let results;
+        try {
+            const rawResults = await this.session.get(this.BASE_URL + "gappserv/live/enterstudio", {
+                params: params,
+                responseType: "json",
+            });
+            results = rawResults.data;
+        } catch (e) {
+            if (e.response) {
+                results = e.response.data;
+            } else {
+                logger.error(`Failed to fetch user ${userId}, ${e.toString()}`);
+                console.error(e);
+                results = { body: {}, code: -1, message: e.toString() };
+            }
+        }
+
+        if (results["code"] !== 0) {
+            logger.error(`An error occured when fetching user ${userId}`);
+            logger.error(`Got error ${results["code"]}, ${results["message"]}`);
+            return undefined;
+        }
+
+        // @ts-ignore
+        const properResults: VideoProps = {};
+        const liveInfo = _.get(results, "body", {});
+        if (is_none(liveInfo)) {
+            logger.error(`User ID ${userId} missing required data to process`);
+            return undefined;
+        }
+        const is_live: number | undefined = _.get(liveInfo, "live_mode", undefined);
+        if (typeof is_live === "undefined") {
+            // Not live
+            return undefined;
+        }
+
+        const liveStart = moment.tz(liveInfo["live_start_ms"], "UTC");
+
+        properResults["id"] = liveInfo["log_id"];
+        properResults["title"] = liveInfo["anchor_intro"];
+        properResults["status"] = "live";
+        properResults["timedata"] = {
+            startTime: liveStart.unix(),
+            // @ts-ignore
+            endTime: null,
+            // @ts-ignore
+            duration: null,
+            publishedAt: liveStart.format(),
+        };
+        properResults["viewers"] = liveInfo["viewers"];
+        properResults["channel_id"] = userId;
+        properResults["thumbnail"] = liveInfo["pic"];
+        properResults["platform"] = "mildom";
+        return properResults;
+    }
+}

--- a/src/graphql/mutations/vtuber/helper/ttvapi.ts
+++ b/src/graphql/mutations/vtuber/helper/ttvapi.ts
@@ -1,0 +1,304 @@
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
+import moment from "moment-timezone";
+import _ from "lodash";
+import { Logger } from "winston";
+
+import { logger as MainLogger } from "../../../../utils/logger";
+import { is_none, resolveDelayCrawlerPromises } from "../../../../utils/swissknife";
+
+import packageJson from "../../../../../package.json";
+
+interface AnyDict {
+    [key: string]: any;
+}
+
+export class TwitchHelix {
+    private cid: string;
+    private csc: string;
+
+    private nextReset: number;
+    private remainingBucket: number;
+
+    private session: AxiosInstance;
+    private authorized: boolean;
+    private bearer_token?: string;
+    private expires: number;
+    private logger: Logger;
+
+    BASE_URL: string;
+    OAUTH_URL: string;
+
+    constructor(client_id: string, client_secret: string) {
+        this.bearer_token = undefined;
+        this.expires = 0;
+        this.cid = client_id;
+        this.csc = client_secret;
+        this.session = axios.create({
+            headers: {
+                "User-Agent": `ihaapi-ts/${packageJson["version"]} (https://github.com/ihateani-me/ihaapi-ts)`,
+            },
+        });
+        this.authorized = false;
+
+        this.BASE_URL = "https://api.twitch.tv/helix/";
+        this.OAUTH_URL = "https://id.twitch.tv/oauth2/";
+
+        this.nextReset = -1;
+        this.remainingBucket = -1;
+
+        this.session.interceptors.response.use(this.handleRateLimitResponse.bind(this), (error) => {
+            return Promise.reject(error);
+        });
+        this.session.interceptors.request.use(this.handleRateLimitRequest.bind(this), (error) => {
+            return Promise.reject(error);
+        });
+        this.logger = MainLogger.child({ cls: "TwitchHelix" });
+    }
+
+    private delayBy(ms: number): Promise<void> {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+    }
+
+    private current() {
+        return moment.tz("UTC").unix();
+    }
+
+    private async handleRateLimitRequest(config: AxiosRequestConfig): Promise<AxiosRequestConfig> {
+        const logger = this.logger.child({ fn: "handleRateLimit" });
+        if (this.remainingBucket < 1 && this.remainingBucket !== -1) {
+            const currentTime = moment.tz("UTC").unix();
+            if (this.nextReset > currentTime) {
+                logger.info(`currently rate limited, delaying by ${this.nextReset - currentTime} seconds`);
+                await this.delayBy((this.nextReset - currentTime) * 1000);
+            }
+        }
+        return config;
+    }
+
+    private handleRateLimitResponse(
+        response: AxiosResponse<any>
+    ): AxiosResponse<any> | Promise<AxiosResponse<any>> {
+        this.nextReset = parseInt(_.get(response.headers, "ratelimit-reset", this.nextReset));
+        this.remainingBucket = parseInt(_.get(response.headers, "ratelimit-remaining", this.remainingBucket));
+        return response;
+    }
+
+    // @ts-ignore
+    private async getReq(url: string, params: AnyDict, headers: AnyDict = null) {
+        let param_url = "";
+        if (typeof params === "object" && Array.isArray(params)) {
+            param_url = params.join("&");
+        } else if (typeof params === "object") {
+            const s_ = [];
+            for (const [key, val] of Object.entries(params)) {
+                s_.push(`${key}=${val}`);
+            }
+            param_url = s_.join("&");
+        } else if (typeof params === "string") {
+            param_url = params;
+        }
+        if (is_none(headers)) {
+            const resp = await this.session.get(`${url}?${param_url}`);
+            return resp.data;
+        } else {
+            const resp = await this.session.get(`${url}?${param_url}`, {
+                headers: headers,
+            });
+            return resp.data;
+        }
+    }
+
+    // @ts-ignore
+    private async postReq(url: string, params: AnyDict, headers: AnyDict = null) {
+        if (is_none(headers)) {
+            const resp = await this.session.post(url, null, {
+                params: params,
+            });
+            return resp.data;
+        } else {
+            const resp = await this.session.post(url, null, {
+                params: params,
+                headers: headers,
+            });
+            return resp.data;
+        }
+    }
+
+    async expireToken() {
+        const logger = this.logger.child({ fn: "expireToken" });
+        const params = { client_id: this.cid, token: this.bearer_token };
+        if (this.authorized) {
+            logger.info("de-authorizing...");
+            await this.postReq(this.OAUTH_URL + "revoke", params);
+            logger.info("de-authorized.");
+            this.expires = 0;
+            this.bearer_token = undefined;
+            this.authorized = false;
+        }
+    }
+
+    async authorizeClient() {
+        const logger = this.logger.child({ fn: "authorizeClient" });
+        const params = { client_id: this.cid, client_secret: this.csc, grant_type: "client_credentials" };
+        logger.info("authorizing...");
+        const res = await this.postReq(this.OAUTH_URL + "token", params);
+        this.expires = this.current() + res["expires_in"];
+        this.bearer_token = res["access_token"];
+        logger.info("authorized.");
+        this.authorized = true;
+    }
+
+    async fetchLivesData(usernames: string[]) {
+        const logger = this.logger.child({ fn: "fetchLivesData" });
+        if (!this.authorized) {
+            logger.warn("You're not authorized yet, requesting new bearer token...");
+            await this.authorizeClient();
+        }
+        if (this.current() >= this.expires) {
+            logger.warn("Token expired, rerequesting...");
+            await this.authorizeClient();
+        }
+
+        const chunkedUsernames = _.chunk(usernames, 90);
+        const headers = {
+            Authorization: `Bearer ${this.bearer_token}`,
+            "Client-ID": this.cid,
+        };
+
+        const chunkedPromises: Promise<any[]>[] = chunkedUsernames.map((username_sets, idx) =>
+            this.getReq(
+                this.BASE_URL + "streams",
+                _.concat(
+                    ["first=100"],
+                    _.map(username_sets, (o) => `user_login=${o}`)
+                ),
+                headers
+            )
+                .then((results: any) => {
+                    return results["data"];
+                })
+                .catch((error: any) => {
+                    logger.error(`Failed to fetch chunk ${idx}, ${error.toString()}`);
+                    return [];
+                })
+        );
+        const chunkedPromisesDelayed = resolveDelayCrawlerPromises(chunkedPromises, 500);
+        const returnedPromises = await Promise.all(chunkedPromisesDelayed);
+        return _.flattenDeep(returnedPromises);
+    }
+
+    async fetchChannels(usernames: string[]) {
+        const logger = this.logger.child({ fn: "fetchChannels" });
+        if (!this.authorized) {
+            logger.warn("You're not authorized yet, requesting new bearer token...");
+            await this.authorizeClient();
+        }
+        if (this.current() >= this.expires) {
+            logger.warn("Token expired, rerequesting...");
+            await this.authorizeClient();
+        }
+
+        const headers = {
+            Authorization: `Bearer ${this.bearer_token}`,
+            "Client-ID": this.cid,
+        };
+        const chunkedUsernames = _.chunk(usernames, 90);
+        const chunkedPromises: Promise<any[]>[] = chunkedUsernames.map((username_sets, idx) =>
+            this.getReq(
+                this.BASE_URL + "users",
+                _.map(username_sets, (o) => `login=${o}`),
+                headers
+            )
+                .then((results: any) => {
+                    return results["data"];
+                })
+                .catch((error: any) => {
+                    logger.error(`Failed to fetch chunk ${idx}, ${error.toString()}`);
+                    return [];
+                })
+        );
+        const chunkedPromisesDelayed = resolveDelayCrawlerPromises(chunkedPromises, 500);
+        const returnedPromises = await Promise.all(chunkedPromisesDelayed);
+        return _.flattenDeep(returnedPromises);
+    }
+
+    async fetchChannelFollowers(user_id: string) {
+        const logger = this.logger.child({ fn: "fetchChannelFollowers" });
+        if (!this.authorized) {
+            logger.warn("You're not authorized yet, requesting new bearer token...");
+            await this.authorizeClient();
+        }
+        if (this.current() >= this.expires) {
+            logger.warn("Token expired, rerequesting...");
+            await this.authorizeClient();
+        }
+
+        const headers = {
+            Authorization: `Bearer ${this.bearer_token}`,
+            "Client-ID": this.cid,
+        };
+        const params: string[] = [`to_id=${user_id}`];
+        const res = await this.getReq(this.BASE_URL + "users/follows", params, headers);
+        return res;
+    }
+
+    async fetchChannelVideos(user_id: string) {
+        const logger = this.logger.child({ fn: "fetchChannelVideos" });
+        if (!this.authorized) {
+            logger.warn("You're not authorized yet, requesting new bearer token...");
+            await this.authorizeClient();
+        }
+        if (this.current() >= this.expires) {
+            logger.warn("Token expired, rerequesting...");
+            await this.authorizeClient();
+        }
+
+        const headers = {
+            Authorization: `Bearer ${this.bearer_token}`,
+            "Client-Id": this.cid,
+        };
+        const params_base: string[] = [`user_id=${user_id}`];
+        let main_results = [];
+        const res = await this.getReq(this.BASE_URL + "videos", [params_base[0], "first=50"], headers);
+        main_results.push(res["data"]);
+        if (Object.keys(res["pagination"]).length < 1) {
+            return main_results;
+        }
+        if (_.has(res["pagination"], "cursor")) {
+            if (is_none(res["pagination"]["cursor"]) || !res["pagination"]["cursor"]) {
+                return main_results;
+            }
+        }
+        let next_page = res["pagination"]["cursor"];
+        if (is_none(next_page) || !next_page) {
+            return main_results;
+        }
+        let doExit = false;
+        while (!doExit) {
+            const next_res = await this.getReq(
+                this.BASE_URL + "videos",
+                [params_base[0], `after=${next_page}`],
+                headers
+            );
+            main_results.push(next_res["data"]);
+            if (Object.keys(res["pagination"]).length < 1) {
+                break;
+            }
+            if (_.has(res["pagination"], "cursor")) {
+                if (is_none(res["pagination"]["cursor"]) || !res["pagination"]["cursor"]) {
+                    doExit = true;
+                    break;
+                }
+            }
+            if (doExit) {
+                break;
+            }
+            next_page = next_res["pagination"]["cursor"];
+            if (is_none(next_page) || !next_page) {
+                break;
+            }
+        }
+        main_results = _.flattenDeep(main_results);
+        return main_results;
+    }
+}

--- a/src/graphql/mutations/vtuber/index.ts
+++ b/src/graphql/mutations/vtuber/index.ts
@@ -1,0 +1,4 @@
+export * from "./youtube";
+export * from "./twitcasting";
+export * from "./twitch";
+export * from "./mildom";

--- a/src/graphql/mutations/vtuber/mildom.ts
+++ b/src/graphql/mutations/vtuber/mildom.ts
@@ -1,0 +1,99 @@
+import _ from "lodash";
+import moment from "moment-timezone";
+
+import { MildomAPI } from "./helper";
+import { logger as MainLogger } from "../../../utils/logger";
+import { ChannelsData, ChannelStatsHistData } from "../../../controller";
+
+export async function mildomChannelsDataset(
+    channelId: string,
+    group: string,
+    en_name: string,
+    mildomAPI: MildomAPI
+) {
+    const logger = MainLogger.child({ fn: "mildomChannelsDataset" });
+    const channels = await ChannelsData.findOne({
+        id: { $eq: channelId },
+        platform: { $eq: "mildom" },
+    }).catch((_e) => {
+        return {};
+    });
+    if (_.get(channels, "id")) {
+        return [false, "Channel already exist on database"];
+    }
+    logger.info("fetching to API...");
+    const mildom_results = await mildomAPI.fetchUser(channelId);
+    if (typeof mildom_results === "undefined") {
+        logger.warn("can't find the channel.");
+        return [false, "Cannot find that Mildom Channel"];
+    }
+    logger.info(`parsing API results...`);
+    const insertData = [];
+    const currentTimestamp = moment.tz("UTC").unix();
+    for (let i = 0; i < [mildom_results].length; i++) {
+        const result = mildom_results;
+        logger.info(`parsing and fetching followers and videos ${result["id"]}`);
+        const videosData = await mildomAPI.fetchVideos(result["id"]);
+        const historyData: any[] = [];
+        historyData.push({
+            timestamp: currentTimestamp,
+            followerCount: result["followerCount"],
+            level: result["level"],
+            videoCount: videosData.length,
+        });
+        // @ts-ignore
+        const mappedNew: MildomChannelProps = {
+            id: result["id"],
+            name: result["name"],
+            en_name: en_name,
+            description: result["description"],
+            thumbnail: result["thumbnail"],
+            followerCount: result["followerCount"],
+            videoCount: videosData.length,
+            level: result["level"],
+            group: group,
+            platform: "mildom",
+        };
+        insertData.push(mappedNew);
+    }
+
+    // @ts-ignore
+    const historyDatas: ChannelStatsHistProps[] = insertData.map((res) => {
+        const timestamp = moment.tz("UTC").unix();
+        return {
+            id: res["id"],
+            history: [
+                {
+                    timestamp: timestamp,
+                    followerCount: res["followerCount"],
+                    level: res["level"],
+                    videoCount: res["videoCount"],
+                },
+            ],
+            group: res["group"],
+            platform: "mildom",
+        };
+    });
+
+    let commitFail = false;
+    if (insertData.length > 0) {
+        logger.info(`committing new data...`);
+        await ChannelsData.insertMany(insertData).catch((err) => {
+            logger.error(`failed to insert new data, ${err.toString()}`);
+            commitFail = true;
+        });
+        await ChannelStatsHistData.insertMany(historyDatas).catch((err) => {
+            logger.error(`Failed to insert new history data, ${err.toString()}`);
+        });
+        if (commitFail) {
+            return [
+                false,
+                "Failed to insert new VTuber to Twitch database, " +
+                    "please try again later or contact the Web Admin",
+            ];
+        }
+        return [true, "Success"];
+    } else {
+        return [false, "Cannot find that Mildom Channel"];
+    }
+}

--- a/src/graphql/mutations/vtuber/twitcasting.ts
+++ b/src/graphql/mutations/vtuber/twitcasting.ts
@@ -1,0 +1,127 @@
+import axios from "axios";
+import _ from "lodash";
+import moment from "moment-timezone";
+
+import { ChannelsData, ChannelsProps, ChannelStatsHistData } from "../../../controller";
+import { logger as MainLogger } from "../../../utils/logger";
+import { is_none } from "../../../utils/swissknife";
+
+const CHROME_UA =
+    // eslint-disable-next-line max-len
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36";
+
+export async function twcastChannelsDataset(channelId: string, group: string, en_name: string) {
+    const session = axios.create({
+        headers: {
+            "User-Agent": CHROME_UA,
+        },
+    });
+    const logger = MainLogger.child({ fn: "twcastChannelDataset" });
+
+    logger.info("checking if channel exist...");
+    const channels = await ChannelsData.findOne({
+        id: { $eq: channelId },
+        platform: { $eq: "twitcasting" },
+    }).catch((_e: any) => {
+        return {};
+    });
+    if (_.get(channels, "id")) {
+        return [false, "Channel already exist on database"];
+    }
+    // @ts-ignore
+    const channelIds = [{ id: channelId, group: group }];
+
+    logger.info("creating fetch jobs...");
+    const channelPromises = channelIds.map((channel) =>
+        session
+            .get(`https://frontendapi.twitcasting.tv/users/${channel.id}`, {
+                params: {
+                    detail: "true",
+                },
+                responseType: "json",
+            })
+            .then((jsonRes) => {
+                return { data: jsonRes.data, group: channel.group };
+            })
+            .catch((err) => {
+                logger.error(`failed fetching for ${channel.id}, error: ${err.toString()}`);
+                return { data: {}, group: channel.group };
+            })
+    );
+    logger.info("executing API requests...");
+    const collectedChannels = (await Promise.all(channelPromises)).filter(
+        (res) => Object.keys(res["data"]).length > 0
+    );
+    const insertData: ChannelsProps[] = [];
+    for (let i = 0; i < collectedChannels.length; i++) {
+        const raw_res = collectedChannels[i];
+        const result = raw_res["data"];
+        if (!_.has(result, "user")) {
+            continue;
+        }
+
+        const udata = result["user"];
+        let desc = "";
+        if (_.has(udata, "description") && !is_none(udata["description"]) && udata["description"] !== "") {
+            desc = udata["description"];
+        }
+        let profile_img: string = udata["image"];
+        if (profile_img.startsWith("//")) {
+            profile_img = "https:" + profile_img;
+        }
+        // @ts-ignore
+        const mappedNew: ChannelsProps = {
+            id: udata["id"],
+            name: udata["name"],
+            en_name: en_name,
+            description: desc,
+            thumbnail: profile_img,
+            followerCount: udata["backerCount"],
+            level: udata["level"],
+            group: raw_res["group"],
+            platform: "twitcasting",
+        };
+        insertData.push(mappedNew);
+    }
+
+    // @ts-ignore
+    const historyDatas: ChannelStatsHistProps[] = insertData.map((res) => {
+        const timestamp = moment.tz("UTC").unix();
+        return {
+            id: res["id"],
+            history: [
+                {
+                    timestamp: timestamp,
+                    followerCount: res["followerCount"],
+                    level: res["level"],
+                },
+            ],
+            group: res["group"],
+            platform: "twitcasting",
+        };
+    });
+
+    if (insertData.length > 0) {
+        logger.info(`committing new data...`);
+        let isCommitError = false;
+        // @ts-ignore
+        await ChannelsData.insertMany(insertData).catch((err) => {
+            logger.error(`failed to insert new data, ${err.toString()}`);
+            isCommitError = true;
+        });
+        await ChannelStatsHistData.insertMany(historyDatas).catch((err) => {
+            logger.error(`Failed to insert new history data, ${err.toString()}`);
+            isCommitError = true;
+        });
+        if (isCommitError) {
+            return [
+                false,
+                "Failed to insert new VTuber to Twitcasting database, " +
+                    "please try again later or contact the Web Admin",
+            ];
+        }
+        return [true, "Success"];
+    } else {
+        return [false, "Cannot find the Twitcasting ID."];
+    }
+}

--- a/src/graphql/mutations/vtuber/twitch.ts
+++ b/src/graphql/mutations/vtuber/twitch.ts
@@ -1,0 +1,117 @@
+import _ from "lodash";
+import moment from "moment-timezone";
+
+import { ChannelsData, ChannelsProps, ChannelStatsHistData } from "../../../controller";
+import { logger as MainLogger } from "../../../utils/logger";
+import { is_none } from "../../../utils/swissknife";
+import { TwitchHelix } from "./helper";
+
+export async function ttvChannelDataset(
+    channelId: string,
+    group: string,
+    en_name: string,
+    ttvAPI: TwitchHelix | undefined
+) {
+    const logger = MainLogger.child({ fn: "ttvChannelDataset" });
+    if (is_none(ttvAPI)) {
+        return [false, "Web Admin doesn't give Twitch API information"];
+    }
+    logger.info(`Searching for ${channelId} on group ${group} with name ${en_name}`);
+
+    const channels = await ChannelsData.findOne({
+        id: { $eq: channelId },
+        platform: { $eq: "twitch" },
+    }).catch((_e) => {
+        return {};
+    });
+    if (_.get(channels, "id")) {
+        return [false, "Channel already exist on database"];
+    }
+    // @ts-ignore
+    const channelIds = [{ id: channelId, group: group }];
+    logger.info("fetching to API...");
+    const twitch_results: any[] = await ttvAPI.fetchChannels([channelId]);
+    if (twitch_results.length < 1) {
+        logger.warn("can't find the channel.");
+        return [false, "Cannot find that Twitch Channel"];
+    }
+    logger.info("parsing API results...");
+    const newChannels: ChannelsProps[] = [];
+    for (let i = 0; i < twitch_results.length; i++) {
+        const result = twitch_results[i];
+        logger.info(`parsing and fetching followers and videos ${result["login"]}`);
+        const followersData = await ttvAPI.fetchChannelFollowers(result["id"]).catch((_e) => {
+            logger.error(`failed to fetch follower list for: ${result["login"]}`);
+            return { total: 0 };
+        });
+        const videosData = (
+            await ttvAPI.fetchChannelVideos(result["id"]).catch((_e) => {
+                logger.error(`failed to fetch video list for: ${result["login"]}`);
+                return [{ viewable: "private" }];
+            })
+        ).filter((vid) => vid["viewable"] === "public");
+        // @ts-ignore
+        const channels_map: VTuberModel = _.find(channelIds, { id: result["login"] });
+        if (is_none(channels_map)) {
+            continue;
+        }
+        // @ts-ignore
+        const mappedUpdate: ChannelsProps = {
+            id: result["login"],
+            user_id: result["id"],
+            name: result["display_name"],
+            en_name: en_name,
+            description: result["description"],
+            thumbnail: result["profile_image_url"],
+            publishedAt: result["created_at"],
+            followerCount: followersData["total"],
+            viewCount: result["view_count"],
+            videoCount: videosData.length,
+            group: group,
+            platform: "twitch",
+        };
+        newChannels.push(mappedUpdate);
+    }
+
+    // @ts-ignore
+    const historyDatas: ChannelStatsHistProps[] = newChannels.map((res) => {
+        const timestamp = moment.tz("UTC").unix();
+        return {
+            id: res["id"],
+            history: [
+                {
+                    timestamp: timestamp,
+                    followerCount: res["followerCount"],
+                    viewCount: res["viewCount"],
+                    videoCount: res["videoCount"],
+                },
+            ],
+            group: res["group"],
+            platform: "twitch",
+        };
+    });
+
+    let commitFail = false;
+    if (newChannels.length > 0) {
+        logger.info(`committing new data...`);
+        // @ts-ignore
+        await ChannelsData.insertMany(newChannels).catch((err) => {
+            logger.error(`failed to insert new data, ${err.toString()}`);
+            commitFail = true;
+        });
+        await ChannelStatsHistData.insertMany(historyDatas).catch((err) => {
+            logger.error(`Failed to insert new history data, ${err.toString()}`);
+            commitFail = true;
+        });
+        if (commitFail) {
+            return [
+                false,
+                "Failed to insert new VTuber to Twitch database, " +
+                    "please try again later or contact the Web Admin",
+            ];
+        }
+        return [true, "Success"];
+    } else {
+        return [false, "Cannot find that Twitch Channel"];
+    }
+}

--- a/src/graphql/mutations/vtuber/youtube.ts
+++ b/src/graphql/mutations/vtuber/youtube.ts
@@ -1,0 +1,214 @@
+import axios from "axios";
+import _ from "lodash";
+import moment from "moment-timezone";
+
+import { ChannelsData, ChannelStatsHistData } from "../../../controller";
+import { fallbackNaN, is_none } from "../../../utils/swissknife";
+import { logger as MainLogger } from "../../../utils/logger";
+
+import config from "../../../config";
+import packageJson from "../../../../package.json";
+
+interface AnyDict {
+    [key: string]: any;
+}
+
+function getBestThumbnail(thumbnails: any, video_id: string): string {
+    if (_.has(thumbnails, "maxres")) {
+        return thumbnails["maxres"]["url"];
+    } else if (_.has(thumbnails, "standard")) {
+        return thumbnails["standard"]["url"];
+    } else if (_.has(thumbnails, "high")) {
+        return thumbnails["high"]["url"];
+    } else if (_.has(thumbnails, "medium")) {
+        return thumbnails["medium"]["url"];
+    } else if (_.has(thumbnails, "default")) {
+        return thumbnails["default"]["url"];
+    }
+    return `https://i.ytimg.com/vi/${video_id}/maxresdefault.jpg`;
+}
+
+function checkForYoutubeAPIError(apiReponses: any) {
+    const errors = _.get(apiReponses, "error", undefined);
+    if (typeof errors === "undefined") {
+        return [false, false];
+    }
+    const errorsData: any[] = _.get(errors, "errors", []);
+    if (errorsData.length < 1) {
+        return [false, false];
+    }
+    const firstErrors = errorsData[0];
+    const errorReason = _.get(firstErrors, "reason", "unknown");
+    if (errorReason === "rateLimitExceeded") {
+        return [true, true];
+    }
+    return [true, false];
+}
+
+export async function youtubeChannelDataset(channelId: string, group: string, en_name: string) {
+    const session = axios.create({
+        headers: {
+            "User-Agent": `ihaapi-ts/${packageJson["version"]} (https://github.com/ihateani-me/ihaapi-ts)`,
+        },
+    });
+    const logger = MainLogger.child({ fn: "youtubeChannelDataset" });
+    if (is_none(config.vtapi.youtube_key)) {
+        return [false, "Web Admin doesn't have YouTube API Key provided on config."];
+    }
+
+    const parsed_yt_channel = await ChannelsData.findOne({
+        id: { $eq: channelId },
+        platform: { $eq: "youtube" },
+    }).catch((_e) => {
+        return {};
+    });
+    if (_.get(parsed_yt_channel, "id")) {
+        return [false, "Channel already exist on database"];
+    }
+
+    // @ts-ignore
+    const channelIds = [{ id: channelId, group: group, name: en_name }];
+
+    const chunked_channels_set = _.chunk(channelIds, 40);
+    logger.info(
+        // eslint-disable-next-line max-len
+        `checking channels with total of ${channelIds.length} channels (${chunked_channels_set.length} chunks)...`
+    );
+    let apiExhausted = false;
+    const items_data_promises = chunked_channels_set.map((chunks, idx) =>
+        session
+            .get("https://www.googleapis.com/youtube/v3/channels", {
+                params: {
+                    part: "snippet,statistics",
+                    id: _.join(_.map(chunks, "id"), ","),
+                    maxResults: 50,
+                    key: config.vtapi.youtube_key,
+                },
+                responseType: "json",
+            })
+            .then((result) => {
+                const yt_result = result.data;
+                const items = yt_result["items"].map((res: any) => {
+                    // @ts-ignore
+                    const channel_data = _.find(channelIds, { id: res.id });
+                    // @ts-ignore
+                    res["groupData"] = channel_data["group"];
+                    // @ts-ignore
+                    res["enName"] = channel_data["name"];
+                    return res;
+                });
+                return items;
+            })
+            .catch((err) => {
+                if (err.response) {
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    const [_e, isAPIExhausted] = checkForYoutubeAPIError(err.response.data);
+                    if (isAPIExhausted) {
+                        apiExhausted = true;
+                    }
+                }
+                logger.error(`failed to fetch info for chunk ${idx}, error: ${err.toString()}`);
+                return [];
+            })
+    );
+
+    let items_data: any[] = await Promise.all(items_data_promises).catch((err) => {
+        logger.error(`failed to fetch from API, error: ${err.toString()}`);
+        return [];
+    });
+    if (apiExhausted) {
+        logger.warn("API key exhausted, please change it");
+        return [false, "API Keys already exhausted, please wait for 24 hours for it to be resetted."];
+    }
+    if (items_data.length < 1) {
+        logger.warn("no response from API");
+        return [false, "Cannot find the Youtube Channel"];
+    }
+
+    items_data = _.flattenDeep(items_data);
+    logger.info(`preparing new data...`);
+    const to_be_committed = items_data.map((res_item) => {
+        const ch_id = res_item["id"];
+        const snippets: AnyDict = res_item["snippet"];
+        const statistics: AnyDict = res_item["statistics"];
+
+        const title = snippets["title"];
+        const desc = snippets["description"];
+        const pubAt = snippets["publishedAt"];
+        const enName = en_name;
+
+        const thumbs = getBestThumbnail(snippets["thumbnails"], "");
+        let subsCount = 0,
+            viewCount = 0,
+            videoCount = 0;
+
+        if (_.has(statistics, "subscriberCount")) {
+            subsCount = fallbackNaN(parseInt, statistics["subscriberCount"], statistics["subscriberCount"]);
+        }
+        if (_.has(statistics, "viewCount")) {
+            viewCount = fallbackNaN(parseInt, statistics["viewCount"], statistics["viewCount"]);
+        }
+        if (_.has(statistics, "videoCount")) {
+            videoCount = fallbackNaN(parseInt, statistics["videoCount"], statistics["videoCount"]);
+        }
+
+        // @ts-ignore
+        const finalData: ChannelsProps = {
+            id: ch_id,
+            name: title,
+            en_name: enName,
+            description: desc,
+            publishedAt: pubAt,
+            thumbnail: thumbs,
+            subscriberCount: subsCount,
+            viewCount: viewCount,
+            videoCount: videoCount,
+            group: group,
+            platform: "youtube",
+        };
+        return finalData;
+    });
+
+    // @ts-ignore
+    const historyDatas: ChannelStatsHistProps[] = to_be_committed.map((res) => {
+        const timestamp = moment.tz("UTC").unix();
+        return {
+            id: res["id"],
+            history: [
+                {
+                    timestamp: timestamp,
+                    subscriberCount: res["subscriberCount"],
+                    viewCount: res["viewCount"],
+                    videoCount: res["videoCount"],
+                },
+            ],
+            group: res["group"],
+            platform: "youtube",
+        };
+    });
+
+    logger.info(`committing new data...`);
+    let commitFail = false;
+    if (to_be_committed.length > 0) {
+        logger.info(`committing new data...`);
+        await ChannelsData.insertMany(to_be_committed).catch((err) => {
+            logger.error(`failed to insert new data, ${err.toString()}`);
+            commitFail = true;
+        });
+    }
+    if (historyDatas.length > 0) {
+        logger.info(`youtubeChannelDataset(${group}) committing new history data...`);
+        await ChannelStatsHistData.insertMany(historyDatas).catch((err) => {
+            logger.error(`failed to insert new history data, ${err.toString()}`);
+            commitFail = true;
+        });
+    }
+    if (commitFail) {
+        return [
+            false,
+            "Failed to insert new VTuber to Youtube database, " +
+                "please try again later or contact the Web Admin",
+        ];
+    }
+    return [true, "Success"];
+}

--- a/src/graphql/schemas/index.ts
+++ b/src/graphql/schemas/index.ts
@@ -213,4 +213,23 @@ export const v2Definitions = gql`
         "Image Board Query"
         imagebooru: ImageBoardQuery!
     }
+
+    """
+    ihateani.me API Mutation
+    """
+    type Mutation {
+        """
+        Add a VTuber channel to the database
+        """
+        VTuberAdd(
+            "Channel ID"
+            id: String!
+            "Channel group association"
+            group: String!
+            "Romanized/English channel name"
+            name: String!
+            "Platform name"
+            platform: PlatformName!
+        ): ChannelObject!
+    }
 `;

--- a/src/graphql/schemas/vtapi.ts
+++ b/src/graphql/schemas/vtapi.ts
@@ -386,3 +386,10 @@ export interface ChannelsResource {
 export interface GroupsResource {
     items: string[];
 }
+
+export interface VTAddMutationParams {
+    id: string;
+    name: string;
+    group: string;
+    platform: PlatformName;
+}

--- a/src/utils/swissknife.test.ts
+++ b/src/utils/swissknife.test.ts
@@ -5,8 +5,11 @@ describe("Filter out empty data from Array", () => {
     test("No data passed.", () => {
         expect(SwissKnife.filter_empty([])).toEqual([]);
     });
-    test("Undefined data and null", () => {
+    test("null data", () => {
         expect(SwissKnife.filter_empty(null)).toEqual([]);
+    });
+    test("undefined data", () => {
+        expect(SwissKnife.filter_empty(undefined)).toEqual([]);
     });
     test("One data passed.", () => {
         expect(SwissKnife.filter_empty(["one"])).toEqual(["one"]);
@@ -301,5 +304,27 @@ describe("Validate the content of a list to the expected data", () => {
     it("Passed data but it's not a list", () => {
         // @ts-ignore
         expect(SwissKnife.validateListData({ a: 1 }, "string")).toEqual({ a: 1 });
+    });
+});
+
+describe("Mock test the resolveCrawlerDelayer", () => {
+    it("Process one", async () => {
+        const testList = ["a", "b", "c", "d", "e"];
+        const promises = testList.map(
+            (res) =>
+                new Promise((resolve, reject) => {
+                    try {
+                        resolve(res);
+                    } catch (e) {
+                        reject(e);
+                    }
+                })
+        );
+        const delayedPromises = SwissKnife.resolveDelayCrawlerPromises(promises, 250);
+        const timeStart = new Date().getTime();
+        await Promise.all(delayedPromises);
+        const timeEnd = new Date().getTime();
+        const deltaTime = timeEnd - timeStart;
+        expect(deltaTime).toBeGreaterThanOrEqual(900);
     });
 });

--- a/src/utils/swissknife.ts
+++ b/src/utils/swissknife.ts
@@ -285,3 +285,17 @@ export function validateListData<T extends any[]>(data: T | Nulled, expected: Ty
     });
     return properExpected;
 }
+
+const delayPromise = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export function resolveDelayCrawlerPromises<T>(
+    requests: Promise<T>[],
+    delayPerRequest: number
+): Promise<T>[] {
+    const remapRequest = requests.map(async (prom, idx) => {
+        await delayPromise(delayPerRequest * idx);
+        const res = await prom;
+        return res;
+    });
+    return remapRequest;
+}


### PR DESCRIPTION
As title said, this will admin to add new VTuber to the database.

Schema:
```gql
"""
ihateani.me API Mutation
"""
type Mutation {
    """
    Add a VTuber channel to the database
    """
    VTuberAdd(
        "Channel ID"
        id: String!
        "Channel group association"
        group: String!
        "Romanized/English channel name"
        name: String!
        "Platform name"
        platform: PlatformName!
    ): ChannelObject!
}
```

Admin need to provide a `Authorization` Header that contains the `secure_password` value defined in config and prepending `password `

Example:
```json
{
	"Authorization": "password my_super_secret_password"
}
```

If the admin doesn't provide it, it will fail.